### PR TITLE
Add Wordbook Resources

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -12,7 +12,7 @@ module Api
 
         return render json: { error: "Invalid ID token" }, status: :unauthorized unless payload
 
-        user = User.find_or_create_by(google_id: payload["sub"]) do |u|
+        user = User.find_or_create_by(provider: "google", provider_uid: payload["sub"]) do |u|
           u.email = payload["email"]
           u.name = payload["name"]
           u.avatar_url = payload["picture"]

--- a/app/controllers/api/v1/examples_controller.rb
+++ b/app/controllers/api/v1/examples_controller.rb
@@ -1,0 +1,49 @@
+module Api
+  module V1
+    class ExamplesController < ApplicationController
+      before_action :set_example, only: [:show, :update, :destroy]
+
+      def index
+        examples = Example.all
+        render json: examples
+      end
+
+      def show
+        render json: @example
+      end
+
+      def create
+        example = Example.new(example_params)
+
+        if example.save
+          render json: example, status: :created
+        else
+          render json: { errors: example.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @example.update(example_params)
+          render json: @example
+        else
+          render json: { errors: @example.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @example.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_example
+        @example = Example.find(params[:id])
+      end
+
+      def example_params
+        params.require(:example).permit(:word_id, :sentence, :translation, :display_order)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/meanings_controller.rb
+++ b/app/controllers/api/v1/meanings_controller.rb
@@ -1,0 +1,49 @@
+module Api
+  module V1
+    class MeaningsController < ApplicationController
+      before_action :set_meaning, only: [:show, :update, :destroy]
+
+      def index
+        meanings = Meaning.all
+        render json: meanings
+      end
+
+      def show
+        render json: @meaning
+      end
+
+      def create
+        meaning = Meaning.new(meaning_params)
+
+        if meaning.save
+          render json: meaning, status: :created
+        else
+          render json: { errors: meaning.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @meaning.update(meaning_params)
+          render json: @meaning
+        else
+          render json: { errors: @meaning.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @meaning.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_meaning
+        @meaning = Meaning.find(params[:id])
+      end
+
+      def meaning_params
+        params.require(:meaning).permit(:word_id, :content, :display_order)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -1,0 +1,49 @@
+module Api
+  module V1
+    class SettingsController < ApplicationController
+      before_action :set_setting, only: [:show, :update, :destroy]
+
+      def index
+        settings = Setting.all
+        render json: settings
+      end
+
+      def show
+        render json: @setting
+      end
+
+      def create
+        setting = Setting.new(setting_params)
+
+        if setting.save
+          render json: setting, status: :created
+        else
+          render json: { errors: setting.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @setting.update(setting_params)
+          render json: @setting
+        else
+          render json: { errors: @setting.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @setting.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_setting
+        @setting = Setting.find(params[:id])
+      end
+
+      def setting_params
+        params.require(:setting).permit(:user_id, :hard_interval_days, :uncertain_interval_days, :easy_interval_days)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/wordbooks_controller.rb
+++ b/app/controllers/api/v1/wordbooks_controller.rb
@@ -1,0 +1,49 @@
+module Api
+  module V1
+    class WordbooksController < ApplicationController
+      before_action :set_wordbook, only: [:show, :update, :destroy]
+
+      def index
+        wordbooks = Wordbook.all
+        render json: wordbooks
+      end
+
+      def show
+        render json: @wordbook
+      end
+
+      def create
+        wordbook = Wordbook.new(wordbook_params)
+
+        if wordbook.save
+          render json: wordbook, status: :created
+        else
+          render json: { errors: wordbook.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @wordbook.update(wordbook_params)
+          render json: @wordbook
+        else
+          render json: { errors: @wordbook.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @wordbook.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_wordbook
+        @wordbook = Wordbook.find(params[:id])
+      end
+
+      def wordbook_params
+        params.require(:wordbook).permit(:user_id, :title)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -1,0 +1,49 @@
+module Api
+  module V1
+    class WordsController < ApplicationController
+      before_action :set_word, only: [:show, :update, :destroy]
+
+      def index
+        words = Word.all
+        render json: words
+      end
+
+      def show
+        render json: @word
+      end
+
+      def create
+        word = Word.new(word_params)
+
+        if word.save
+          render json: word, status: :created
+        else
+          render json: { errors: word.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @word.update(word_params)
+          render json: @word
+        else
+          render json: { errors: @word.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @word.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_word
+        @word = Word.find(params[:id])
+      end
+
+      def word_params
+        params.require(:word).permit(:wordbook_id, :spelling, :status, :next_review_date)
+      end
+    end
+  end
+end

--- a/app/models/example.rb
+++ b/app/models/example.rb
@@ -1,0 +1,7 @@
+class Example < ApplicationRecord
+  belongs_to :word
+
+  validates :sentence, presence: true
+  validates :translation, presence: true
+  validates :display_order, presence: true, numericality: { only_integer: true, greater_than: 0 }
+end

--- a/app/models/meaning.rb
+++ b/app/models/meaning.rb
@@ -1,0 +1,6 @@
+class Meaning < ApplicationRecord
+  belongs_to :word
+
+  validates :content, presence: true
+  validates :display_order, presence: true, numericality: { only_integer: true, greater_than: 0 }
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,0 +1,7 @@
+class Setting < ApplicationRecord
+  belongs_to :user
+
+  validates :hard_interval_days, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :uncertain_interval_days, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :easy_interval_days, presence: true, numericality: { only_integer: true, greater_than: 0 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  has_many :wordbooks, dependent: :destroy
+  has_one :setting, dependent: :destroy
+
   validates :email, presence: true, uniqueness: true
   validates :google_id, presence: true, uniqueness: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,6 @@ class User < ApplicationRecord
   has_one :setting, dependent: :destroy
 
   validates :email, presence: true, uniqueness: true
-  validates :google_id, presence: true, uniqueness: true
+  validates :provider, presence: true
+  validates :provider_uid, presence: true, uniqueness: { scope: :provider }
 end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -1,0 +1,10 @@
+class Word < ApplicationRecord
+  belongs_to :wordbook
+  has_many :meanings, dependent: :destroy
+  has_many :examples, dependent: :destroy
+
+  validates :spelling, presence: true
+  validates :status, presence: true
+
+  enum :status, { learning: 'learning', learned: 'learned' }
+end

--- a/app/models/wordbook.rb
+++ b/app/models/wordbook.rb
@@ -1,0 +1,6 @@
+class Wordbook < ApplicationRecord
+  belongs_to :user
+  has_many :words, dependent: :destroy
+
+  validates :title, presence: true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,13 @@ Rails.application.routes.draw do
     namespace :v1 do
       # Authentication
       post "auth/google", to: "auth#google"
+
+      # Resources
+      resources :wordbooks
+      resources :words
+      resources :meanings
+      resources :examples
+      resources :settings
     end
   end
 

--- a/db/migrate/20260216000001_create_wordbooks.rb
+++ b/db/migrate/20260216000001_create_wordbooks.rb
@@ -1,0 +1,10 @@
+class CreateWordbooks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :wordbooks do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260216000002_create_words.rb
+++ b/db/migrate/20260216000002_create_words.rb
@@ -1,0 +1,12 @@
+class CreateWords < ActiveRecord::Migration[8.1]
+  def change
+    create_table :words do |t|
+      t.references :wordbook, null: false, foreign_key: true
+      t.string :spelling, null: false
+      t.string :status, null: false
+      t.date :next_review_date
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260216000003_create_meanings.rb
+++ b/db/migrate/20260216000003_create_meanings.rb
@@ -1,0 +1,11 @@
+class CreateMeanings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :meanings do |t|
+      t.references :word, null: false, foreign_key: true
+      t.text :content, null: false
+      t.integer :display_order, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260216000004_create_examples.rb
+++ b/db/migrate/20260216000004_create_examples.rb
@@ -1,0 +1,12 @@
+class CreateExamples < ActiveRecord::Migration[8.1]
+  def change
+    create_table :examples do |t|
+      t.references :word, null: false, foreign_key: true
+      t.text :sentence, null: false
+      t.text :translation, null: false
+      t.integer :display_order, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260216000005_create_settings.rb
+++ b/db/migrate/20260216000005_create_settings.rb
@@ -1,0 +1,12 @@
+class CreateSettings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :settings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :hard_interval_days, null: false
+      t.integer :uncertain_interval_days, null: false
+      t.integer :easy_interval_days, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260217134142_update_users_schema_to_match_er_diagram.rb
+++ b/db/migrate/20260217134142_update_users_schema_to_match_er_diagram.rb
@@ -1,0 +1,15 @@
+class UpdateUsersSchemaToMatchErDiagram < ActiveRecord::Migration[8.1]
+  def change
+    # google_id を provider_uid にリネーム
+    rename_column :users, :google_id, :provider_uid
+    
+    # provider カラムを追加（必須）
+    add_column :users, :provider, :string, null: false, default: 'google'
+    
+    # guest_expires_at カラムを追加
+    add_column :users, :guest_expires_at, :datetime
+    
+    # デフォルト値を削除（既存データに適用済み）
+    change_column_default :users, :provider, from: 'google', to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_23_055911) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_16_000005) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "examples", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "display_order", null: false
+    t.text "sentence", null: false
+    t.text "translation", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "word_id", null: false
+    t.index ["word_id"], name: "index_examples_on_word_id"
+  end
+
+  create_table "meanings", force: :cascade do |t|
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.integer "display_order", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "word_id", null: false
+    t.index ["word_id"], name: "index_meanings_on_word_id"
+  end
+
+  create_table "settings", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "easy_interval_days", null: false
+    t.integer "hard_interval_days", null: false
+    t.integer "uncertain_interval_days", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_settings_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "avatar_url"
@@ -22,4 +51,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_23_055911) do
     t.string "name"
     t.datetime "updated_at", null: false
   end
+
+  create_table "wordbooks", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_wordbooks_on_user_id"
+  end
+
+  create_table "words", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.date "next_review_date"
+    t.string "spelling", null: false
+    t.string "status", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "wordbook_id", null: false
+    t.index ["wordbook_id"], name: "index_words_on_wordbook_id"
+  end
+
+  add_foreign_key "examples", "words"
+  add_foreign_key "meanings", "words"
+  add_foreign_key "settings", "users"
+  add_foreign_key "wordbooks", "users"
+  add_foreign_key "words", "wordbooks"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_16_000005) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_17_134142) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -47,8 +47,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_16_000005) do
     t.string "avatar_url"
     t.datetime "created_at", null: false
     t.string "email"
-    t.string "google_id"
+    t.datetime "guest_expires_at"
     t.string "name"
+    t.string "provider", null: false
+    t.string "provider_uid"
     t.datetime "updated_at", null: false
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,14 +14,16 @@ puts "Creating test users..."
 user1 = User.create!(
   email: "test@example.com",
   name: "Test User",
-  google_id: "test123",
+  provider: "google",
+  provider_uid: "test123",
   avatar_url: "https://example.com/avatar.jpg"
 )
 
 user2 = User.create!(
   email: "demo@example.com",
   name: "Demo User",
-  google_id: "demo456",
+  provider: "google",
+  provider_uid: "demo456",
   avatar_url: "https://example.com/demo.jpg"
 )
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,141 @@
 # This file should ensure the existence of records required to run the application in every environment (production,
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+
+puts "Cleaning database..."
+Setting.destroy_all
+Example.destroy_all
+Meaning.destroy_all
+Word.destroy_all
+Wordbook.destroy_all
+User.destroy_all
+
+puts "Creating test users..."
+user1 = User.create!(
+  email: "test@example.com",
+  name: "Test User",
+  google_id: "test123",
+  avatar_url: "https://example.com/avatar.jpg"
+)
+
+user2 = User.create!(
+  email: "demo@example.com",
+  name: "Demo User",
+  google_id: "demo456",
+  avatar_url: "https://example.com/demo.jpg"
+)
+
+puts "Creating settings..."
+Setting.create!(
+  user: user1,
+  hard_interval_days: 1,
+  uncertain_interval_days: 3,
+  easy_interval_days: 7
+)
+
+Setting.create!(
+  user: user2,
+  hard_interval_days: 2,
+  uncertain_interval_days: 5,
+  easy_interval_days: 10
+)
+
+puts "Creating wordbooks..."
+wordbook1 = Wordbook.create!(
+  user: user1,
+  title: "英単語基礎"
+)
+
+wordbook2 = Wordbook.create!(
+  user: user1,
+  title: "ビジネス英語"
+)
+
+wordbook3 = Wordbook.create!(
+  user: user2,
+  title: "TOEIC対策"
+)
+
+puts "Creating words..."
+word1 = Word.create!(
+  wordbook: wordbook1,
+  spelling: "apple",
+  status: "learning",
+  next_review_date: Date.today + 1
+)
+
+word2 = Word.create!(
+  wordbook: wordbook1,
+  spelling: "book",
+  status: "learning",
+  next_review_date: Date.today + 3
+)
+
+word3 = Word.create!(
+  wordbook: wordbook2,
+  spelling: "negotiate",
+  status: "learning",
+  next_review_date: Date.today + 2
+)
+
+puts "Creating meanings..."
+Meaning.create!(
+  word: word1,
+  content: "りんご",
+  display_order: 1
+)
+
+Meaning.create!(
+  word: word2,
+  content: "本",
+  display_order: 1
+)
+
+Meaning.create!(
+  word: word2,
+  content: "予約する",
+  display_order: 2
+)
+
+Meaning.create!(
+  word: word3,
+  content: "交渉する",
+  display_order: 1
+)
+
+puts "Creating examples..."
+Example.create!(
+  word: word1,
+  sentence: "I like apples.",
+  translation: "私はりんごが好きです。",
+  display_order: 1
+)
+
+Example.create!(
+  word: word1,
+  sentence: "This is a red apple.",
+  translation: "これは赤いりんごです。",
+  display_order: 2
+)
+
+Example.create!(
+  word: word2,
+  sentence: "I read a book every day.",
+  translation: "私は毎日本を読みます。",
+  display_order: 1
+)
+
+Example.create!(
+  word: word3,
+  sentence: "We need to negotiate the terms.",
+  translation: "私たちは条件を交渉する必要があります。",
+  display_order: 1
+)
+
+puts "Seed data created successfully!"
+puts "Users: #{User.count}"
+puts "Settings: #{Setting.count}"
+puts "Wordbooks: #{Wordbook.count}"
+puts "Words: #{Word.count}"
+puts "Meanings: #{Meaning.count}"
+puts "Examples: #{Example.count}"

--- a/docs/scaffold_wordbook_resources.md
+++ b/docs/scaffold_wordbook_resources.md
@@ -1,0 +1,494 @@
+# Wordbook Resources 構築手順
+
+このドキュメントでは、wordbeetle-api に単語帳機能のリソース（モデル、コントローラ、マイグレーション）を追加する手順を説明します。
+
+## 1. ブランチの作成
+
+```bash
+git checkout -b feature/scaffold-wordbook-resources
+```
+
+## 2. モデルとマイグレーションの生成
+
+### Wordbook モデル
+
+```bash
+bin/rails generate model Wordbook user:references title:string
+```
+
+生成後、マイグレーションファイルを編集して `null: false` 制約を追加：
+
+```ruby
+# db/migrate/YYYYMMDDHHMMSS_create_wordbooks.rb
+class CreateWordbooks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :wordbooks do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+
+      t.timestamps
+    end
+  end
+end
+```
+
+モデルファイルにバリデーションとアソシエーションを追加：
+
+```ruby
+# app/models/wordbook.rb
+class Wordbook < ApplicationRecord
+  belongs_to :user
+  has_many :words, dependent: :destroy
+
+  validates :title, presence: true
+end
+```
+
+### Word モデル
+
+```bash
+bin/rails generate model Word wordbook:references spelling:string status:string next_review_date:date
+```
+
+マイグレーションファイルを編集：
+
+```ruby
+# db/migrate/YYYYMMDDHHMMSS_create_words.rb
+class CreateWords < ActiveRecord::Migration[8.1]
+  def change
+    create_table :words do |t|
+      t.references :wordbook, null: false, foreign_key: true
+      t.string :spelling, null: false
+      t.string :status, null: false
+      t.date :next_review_date
+
+      t.timestamps
+    end
+  end
+end
+```
+
+モデルファイルを編集：
+
+```ruby
+# app/models/word.rb
+class Word < ApplicationRecord
+  belongs_to :wordbook
+  has_many :meanings, dependent: :destroy
+  has_many :examples, dependent: :destroy
+
+  validates :spelling, presence: true
+  validates :status, presence: true
+
+  enum :status, { learning: 'learning', learned: 'learned' }
+end
+```
+
+### Meaning モデル
+
+```bash
+bin/rails generate model Meaning word:references content:text display_order:integer
+```
+
+マイグレーションファイルを編集：
+
+```ruby
+# db/migrate/YYYYMMDDHHMMSS_create_meanings.rb
+class CreateMeanings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :meanings do |t|
+      t.references :word, null: false, foreign_key: true
+      t.text :content, null: false
+      t.integer :display_order, null: false
+
+      t.timestamps
+    end
+  end
+end
+```
+
+モデルファイルを編集：
+
+```ruby
+# app/models/meaning.rb
+class Meaning < ApplicationRecord
+  belongs_to :word
+
+  validates :content, presence: true
+  validates :display_order, presence: true, numericality: { only_integer: true, greater_than: 0 }
+end
+```
+
+### Example モデル
+
+```bash
+bin/rails generate model Example word:references sentence:text translation:text display_order:integer
+```
+
+マイグレーションファイルを編集：
+
+```ruby
+# db/migrate/YYYYMMDDHHMMSS_create_examples.rb
+class CreateExamples < ActiveRecord::Migration[8.1]
+  def change
+    create_table :examples do |t|
+      t.references :word, null: false, foreign_key: true
+      t.text :sentence, null: false
+      t.text :translation, null: false
+      t.integer :display_order, null: false
+
+      t.timestamps
+    end
+  end
+end
+```
+
+モデルファイルを編集：
+
+```ruby
+# app/models/example.rb
+class Example < ApplicationRecord
+  belongs_to :word
+
+  validates :sentence, presence: true
+  validates :translation, presence: true
+  validates :display_order, presence: true, numericality: { only_integer: true, greater_than: 0 }
+end
+```
+
+### Setting モデル
+
+```bash
+bin/rails generate model Setting user:references hard_interval_days:integer uncertain_interval_days:integer easy_interval_days:integer
+```
+
+マイグレーションファイルを編集：
+
+```ruby
+# db/migrate/YYYYMMDDHHMMSS_create_settings.rb
+class CreateSettings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :settings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :hard_interval_days, null: false
+      t.integer :uncertain_interval_days, null: false
+      t.integer :easy_interval_days, null: false
+
+      t.timestamps
+    end
+  end
+end
+```
+
+モデルファイルを編集：
+
+```ruby
+# app/models/setting.rb
+class Setting < ApplicationRecord
+  belongs_to :user
+
+  validates :hard_interval_days, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :uncertain_interval_days, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :easy_interval_days, presence: true, numericality: { only_integer: true, greater_than: 0 }
+end
+```
+
+### User モデルにアソシエーション追加
+
+```ruby
+# app/models/user.rb
+class User < ApplicationRecord
+  has_many :wordbooks, dependent: :destroy
+  has_one :setting, dependent: :destroy
+
+  validates :email, presence: true, uniqueness: true
+  validates :google_id, presence: true, uniqueness: true
+end
+```
+
+## 3. マイグレーションの実行
+
+```bash
+bin/rails db:migrate
+```
+
+## 4. コントローラの生成
+
+### Wordbooks コントローラ
+
+```bash
+bin/rails generate controller Api::V1::Wordbooks --skip-routes --skip-helper --skip-assets
+```
+
+生成されたコントローラファイルを編集：
+
+```ruby
+# app/controllers/api/v1/wordbooks_controller.rb
+module Api
+  module V1
+    class WordbooksController < ApplicationController
+      before_action :set_wordbook, only: [:show, :update, :destroy]
+
+      def index
+        wordbooks = Wordbook.all
+        render json: wordbooks
+      end
+
+      def show
+        render json: @wordbook
+      end
+
+      def create
+        wordbook = Wordbook.new(wordbook_params)
+
+        if wordbook.save
+          render json: wordbook, status: :created
+        else
+          render json: { errors: wordbook.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @wordbook.update(wordbook_params)
+          render json: @wordbook
+        else
+          render json: { errors: @wordbook.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @wordbook.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_wordbook
+        @wordbook = Wordbook.find(params[:id])
+      end
+
+      def wordbook_params
+        params.require(:wordbook).permit(:user_id, :title)
+      end
+    end
+  end
+end
+```
+
+### 同様に他のコントローラも生成
+
+```bash
+bin/rails generate controller Api::V1::Words --skip-routes --skip-helper --skip-assets
+bin/rails generate controller Api::V1::Meanings --skip-routes --skip-helper --skip-assets
+bin/rails generate controller Api::V1::Examples --skip-routes --skip-helper --skip-assets
+bin/rails generate controller Api::V1::Settings --skip-routes --skip-helper --skip-assets
+```
+
+各コントローラファイルに CRUD アクションを実装（Wordbooks コントローラと同様のパターン）
+
+## 5. ルーティングの設定
+
+```ruby
+# config/routes.rb
+Rails.application.routes.draw do
+  get "up" => "rails/health#show", as: :rails_health_check
+
+  namespace :api do
+    namespace :v1 do
+      # Authentication
+      post "auth/google", to: "auth#google"
+
+      # Resources
+      resources :wordbooks
+      resources :words
+      resources :meanings
+      resources :examples
+      resources :settings
+    end
+  end
+end
+```
+
+ルーティングの確認：
+
+```bash
+bin/rails routes | grep api
+```
+
+## 6. シードデータの作成
+
+```ruby
+# db/seeds.rb
+# テスト用のシードデータ
+
+puts "Cleaning database..."
+Setting.destroy_all
+Example.destroy_all
+Meaning.destroy_all
+Word.destroy_all
+Wordbook.destroy_all
+User.destroy_all
+
+puts "Creating test users..."
+user1 = User.create!(
+  email: "test@example.com",
+  name: "Test User",
+  google_id: "test123",
+  avatar_url: "https://example.com/avatar.jpg"
+)
+
+user2 = User.create!(
+  email: "demo@example.com",
+  name: "Demo User",
+  google_id: "demo456",
+  avatar_url: "https://example.com/demo.jpg"
+)
+
+puts "Creating settings..."
+Setting.create!(
+  user: user1,
+  hard_interval_days: 1,
+  uncertain_interval_days: 3,
+  easy_interval_days: 7
+)
+
+puts "Creating wordbooks..."
+wordbook1 = Wordbook.create!(
+  user: user1,
+  title: "英単語基礎"
+)
+
+wordbook2 = Wordbook.create!(
+  user: user1,
+  title: "ビジネス英語"
+)
+
+puts "Creating words..."
+word1 = Word.create!(
+  wordbook: wordbook1,
+  spelling: "apple",
+  status: "learning",
+  next_review_date: Date.today + 1
+)
+
+word2 = Word.create!(
+  wordbook: wordbook1,
+  spelling: "book",
+  status: "learning",
+  next_review_date: Date.today + 3
+)
+
+puts "Creating meanings..."
+Meaning.create!(
+  word: word1,
+  content: "りんご",
+  display_order: 1
+)
+
+Meaning.create!(
+  word: word2,
+  content: "本",
+  display_order: 1
+)
+
+puts "Creating examples..."
+Example.create!(
+  word: word1,
+  sentence: "I like apples.",
+  translation: "私はりんごが好きです。",
+  display_order: 1
+)
+
+puts "Seed data created successfully!"
+puts "Users: #{User.count}"
+puts "Settings: #{Setting.count}"
+puts "Wordbooks: #{Wordbook.count}"
+puts "Words: #{Word.count}"
+puts "Meanings: #{Meaning.count}"
+puts "Examples: #{Example.count}"
+```
+
+シードデータの投入：
+
+```bash
+bin/rails db:seed
+```
+
+## 7. 動作確認
+
+### サーバーの起動
+
+```bash
+bin/rails server -p 3001
+```
+
+### API のテスト
+
+```bash
+# Wordbooks 一覧取得
+curl http://localhost:3001/api/v1/wordbooks | python3 -m json.tool
+
+# Words 一覧取得
+curl http://localhost:3001/api/v1/words | python3 -m json.tool
+
+# 特定の Word 取得
+curl http://localhost:3001/api/v1/words/1 | python3 -m json.tool
+
+# Wordbook 作成
+curl -X POST http://localhost:3001/api/v1/wordbooks \
+  -H "Content-Type: application/json" \
+  -d '{"wordbook": {"user_id": 1, "title": "新しい単語帳"}}' | python3 -m json.tool
+
+# Meanings 一覧取得
+curl http://localhost:3001/api/v1/meanings | python3 -m json.tool
+
+# Examples 一覧取得
+curl http://localhost:3001/api/v1/examples | python3 -m json.tool
+```
+
+## 8. コミット
+
+```bash
+git add .
+git commit -m "Add wordbook resources (models, controllers, migrations)"
+```
+
+## 注意事項
+
+- マイグレーションファイルのタイムスタンプは生成時に自動で付与されます
+- `enum` の構文は Rails 8.1 では `enum :attribute, { ... }` の形式を使用します
+- 外部キー制約は `foreign_key: true` で自動的に設定されます
+- `dependent: :destroy` により親レコード削除時に関連レコードも削除されます
+
+## 生成されたファイル一覧
+
+### モデル (5)
+
+- `app/models/wordbook.rb`
+- `app/models/word.rb`
+- `app/models/meaning.rb`
+- `app/models/example.rb`
+- `app/models/setting.rb`
+
+### コントローラ (5)
+
+- `app/controllers/api/v1/wordbooks_controller.rb`
+- `app/controllers/api/v1/words_controller.rb`
+- `app/controllers/api/v1/meanings_controller.rb`
+- `app/controllers/api/v1/examples_controller.rb`
+- `app/controllers/api/v1/settings_controller.rb`
+
+### マイグレーション (5)
+
+- `db/migrate/YYYYMMDDHHMMSS_create_wordbooks.rb`
+- `db/migrate/YYYYMMDDHHMMSS_create_words.rb`
+- `db/migrate/YYYYMMDDHHMMSS_create_meanings.rb`
+- `db/migrate/YYYYMMDDHHMMSS_create_examples.rb`
+- `db/migrate/YYYYMMDDHHMMSS_create_settings.rb`
+
+### その他の変更ファイル
+
+- `app/models/user.rb` (アソシエーション追加)
+- `config/routes.rb` (ルーティング追加)
+- `db/schema.rb` (自動更新)
+- `db/seeds.rb` (テストデータ作成)


### PR DESCRIPTION
## Overview

This PR implements the core wordbook functionality by adding models, controllers, and database migrations according to the ER diagram.

## Changes Summary

### 📊 Database Schema Changes

#### New Tables Created
- **wordbooks** - User's word collections
- **words** - Individual words within wordbooks
- **meanings** - Multiple meanings per word
- **examples** - Example sentences for words
- **settings** - User-specific interval settings for spaced repetition

#### Users Table Updates
- Renamed `google_id` → `provider_uid` (to support multiple auth providers)
- Added `provider` column (required, e.g., "google")
- Added `guest_expires_at` column (for guest user functionality)

### 🏗️ Models (5 new)

#### Wordbook Model
- Belongs to user
- Has many words (with dependent destroy)
- Validates title presence

#### Word Model
- Belongs to wordbook
- Has many meanings and examples (with dependent destroy)
- Validates spelling and status presence
- Enum for status: `learning`, `learned`

#### Meaning Model
- Belongs to word
- Validates content and display_order presence
- Validates display_order is positive integer

#### Example Model
- Belongs to word
- Validates sentence, translation, and display_order presence
- Validates display_order is positive integer

#### Setting Model
- Belongs to user
- Validates all interval days (hard, uncertain, easy) presence and positive integers

### 🎮 Controllers (5 new)

All controllers follow RESTful conventions with CRUD operations:
- `Api::V1::WordbooksController`
- `Api::V1::WordsController`
- `Api::V1::MeaningsController`
- `Api::V1::ExamplesController`
- `Api::V1::SettingsController`

Each controller includes:
- `index` - List all resources
- `show` - Get single resource
- `create` - Create new resource
- `update` - Update existing resource
- `destroy` - Delete resource
- Strong parameters for security

### 🛣️ Routes

Added RESTful routes for all new resources:
```ruby
namespace :api do
  namespace :v1 do
    resources :wordbooks
    resources :words
    resources :meanings
    resources :examples
    resources :settings
  end
end
```

### 🗄️ Migrations (6 files)

1. `20260216000001_create_wordbooks.rb`
2. `20260216000002_create_words.rb`
3. `20260216000003_create_meanings.rb`
4. `20260216000004_create_examples.rb`
5. `20260216000005_create_settings.rb`
6. `20260217134142_update_users_schema_to_match_er_diagram.rb`

All migrations include:
- Foreign key constraints
- NOT NULL constraints where required
- Proper indexing on foreign keys

### 🌱 Seed Data

Added comprehensive test data:
- 2 test users
- 2 user settings
- 3 wordbooks
- 3 words (apple, book, negotiate)
- 4 meanings
- 4 example sentences

### 🔄 Updated Files

#### User Model
- Added `has_many :wordbooks`
- Added `has_one :setting`
- Updated validations to use `provider` and `provider_uid`

#### Auth Controller
- Updated to use `provider` and `provider_uid` instead of `google_id`

## Data Model Structure

```
User
├── has_many Wordbooks
└── has_one Setting

Wordbook
└── has_many Words

Word
├── has_many Meanings
└── has_many Examples
```

## Testing

All APIs have been tested and verified:

### GET Endpoints
- `GET /api/v1/wordbooks` - Returns all wordbooks
- `GET /api/v1/words` - Returns all words
- `GET /api/v1/words/:id` - Returns specific word
- `GET /api/v1/meanings` - Returns all meanings
- `GET /api/v1/examples` - Returns all examples

### POST Endpoints
- `POST /api/v1/wordbooks` - Creates new wordbook
- Verified with test data creation

## Database Constraints

All relationships are protected at multiple levels:

1. **Database Level**: Foreign key constraints, NOT NULL constraints
2. **Rails Level**: `belongs_to` associations (required by default in Rails 5+)
3. **Model Level**: Custom validations for business logic

## Breaking Changes

⚠️ **User Model Schema Change**
- The `google_id` column has been renamed to `provider_uid`
- A new required `provider` column has been added
- Existing code that references `google_id` needs to be updated

This change enables future support for multiple authentication providers (GitHub, Facebook, etc.)

## Migration Notes

To apply these changes:

```bash
# Run migrations
bin/rails db:migrate

# Seed test data (optional)
bin/rails db:seed
```

To rollback if needed:

```bash
bin/rails db:rollback STEP=6
```

## Next Steps

After merging this PR:
1. Add authentication middleware to protect endpoints
2. Implement user-scoped queries (filter wordbooks by current user)
3. Add pagination for list endpoints
4. Add serializers for better JSON response formatting
5. Add comprehensive test coverage (RSpec)
6. Add guest user functionality using `guest_expires_at`

## Checklist

- [x] Database migrations created and tested
- [x] Models with proper associations and validations
- [x] Controllers with CRUD operations
- [x] Routes configured
- [x] Seed data added and tested
- [x] Manual API testing completed
- [x] Documentation updated
- [ ] Automated tests added (future work)
- [ ] Authentication/authorization added (future work)
