### PR TITLE
Enforce user identity integrity with DB-level constraints

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -12,8 +12,17 @@ module Api
 
         return render json: { error: "Invalid ID token" }, status: :unauthorized unless payload
 
+        email = payload["email"]
+        existing_user = User.find_by(email: email) if email.present?
+
+        if existing_user && existing_user.provider != "google"
+          return render json: {
+            error: "This email is already registered with #{existing_user.provider}. Please sign in with #{existing_user.provider}."
+          }, status: :conflict
+        end
+
         user = User.find_or_create_by(provider: "google", provider_uid: payload["sub"]) do |u|
-          u.email = payload["email"]
+          u.email = email
           u.name = payload["name"]
           u.avatar_url = payload["picture"]
         end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   has_many :wordbooks, dependent: :destroy
   has_one :setting, dependent: :destroy
 
-  validates :email, presence: true, uniqueness: true
+  validates :email, uniqueness: { allow_nil: true }
   validates :provider, presence: true
   validates :provider_uid, presence: true, uniqueness: { scope: :provider }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
   validates :email, uniqueness: { allow_nil: true }
   validates :provider, presence: true
   validates :provider_uid, presence: true, uniqueness: { scope: :provider }
+  validates :guest_expires_at, presence: true, if: -> { provider == "guest" }
 end

--- a/db/migrate/20260219142721_add_unique_index_to_users_provider_and_provider_uid.rb
+++ b/db/migrate/20260219142721_add_unique_index_to_users_provider_and_provider_uid.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToUsersProviderAndProviderUid < ActiveRecord::Migration[8.1]
+  def change
+    add_index :users, [:provider, :provider_uid], unique: true, name: 'index_users_on_provider_and_provider_uid'
+  end
+end

--- a/db/migrate/20260221061439_add_not_null_to_users_provider_uid.rb
+++ b/db/migrate/20260221061439_add_not_null_to_users_provider_uid.rb
@@ -1,0 +1,5 @@
+class AddNotNullToUsersProviderUid < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :users, :provider_uid, false
+  end
+end

--- a/db/migrate/20260221062453_add_unique_index_to_users_email.rb
+++ b/db/migrate/20260221062453_add_unique_index_to_users_email.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToUsersEmail < ActiveRecord::Migration[8.1]
+  def change
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20260222131840_add_check_constraint_guest_expires_at.rb
+++ b/db/migrate/20260222131840_add_check_constraint_guest_expires_at.rb
@@ -1,0 +1,7 @@
+class AddCheckConstraintGuestExpiresAt < ActiveRecord::Migration[8.1]
+  def change
+    add_check_constraint :users,
+      "provider != 'guest' OR guest_expires_at IS NOT NULL",
+      name: "check_guest_expires_at_presence"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_19_142721) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_21_061439) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -50,7 +50,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_142721) do
     t.datetime "guest_expires_at"
     t.string "name"
     t.string "provider", null: false
-    t.string "provider_uid"
+    t.string "provider_uid", null: false
     t.datetime "updated_at", null: false
     t.index ["provider", "provider_uid"], name: "index_users_on_provider_and_provider_uid", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_17_134142) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_19_142721) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -52,6 +52,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_17_134142) do
     t.string "provider", null: false
     t.string "provider_uid"
     t.datetime "updated_at", null: false
+    t.index ["provider", "provider_uid"], name: "index_users_on_provider_and_provider_uid", unique: true
   end
 
   create_table "wordbooks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_21_062453) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_22_131840) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -54,6 +54,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_21_062453) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "provider_uid"], name: "index_users_on_provider_and_provider_uid", unique: true
+    t.check_constraint "provider::text <> 'guest'::text OR guest_expires_at IS NOT NULL", name: "check_guest_expires_at_presence"
   end
 
   create_table "wordbooks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_21_061439) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_21_062453) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -52,6 +52,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_21_061439) do
     t.string "provider", null: false
     t.string "provider_uid", null: false
     t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "provider_uid"], name: "index_users_on_provider_and_provider_uid", unique: true
   end
 


### PR DESCRIPTION
## Summary

- Add unique index on `(provider, provider_uid)` to prevent duplicate user identities at the DB level
- Add NOT NULL constraint to `users.provider_uid` at the DB level
- Add unique index to `users.email` at the DB level
- Prevent cross-provider duplicate registration: returns `409 Conflict` when a Google sign-in uses an email already registered under a different provider
- Add DB-level check constraint (`check_guest_expires_at_presence`) requiring `guest_expires_at` to be non-null for guest users; also enforced at the model validation level
- Relax model-level email validation to allow nil (supporting guest users who may not have an email)

## Migrations

| Migration | Description |
|-----------|-------------|
| `20260219142721` | Unique index on `(provider, provider_uid)` |
| `20260221061439` | NOT NULL on `provider_uid` |
| `20260221062453` | Unique index on `email` |
| `20260222131840` | Check constraint for guest `expires_at` |