### PR TITLE
Fix RuboCop offenses across controllers, models, and migrations

### DIFF
--- a/app/controllers/api/v1/examples_controller.rb
+++ b/app/controllers/api/v1/examples_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class ExamplesController < ApplicationController
-      before_action :set_example, only: [:show, :update, :destroy]
+      before_action :set_example, only: [ :show, :update, :destroy ]
 
       def index
         examples = Example.all

--- a/app/controllers/api/v1/meanings_controller.rb
+++ b/app/controllers/api/v1/meanings_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class MeaningsController < ApplicationController
-      before_action :set_meaning, only: [:show, :update, :destroy]
+      before_action :set_meaning, only: [ :show, :update, :destroy ]
 
       def index
         meanings = Meaning.all

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class SettingsController < ApplicationController
-      before_action :set_setting, only: [:show, :update, :destroy]
+      before_action :set_setting, only: [ :show, :update, :destroy ]
 
       def index
         settings = Setting.all

--- a/app/controllers/api/v1/wordbooks_controller.rb
+++ b/app/controllers/api/v1/wordbooks_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class WordbooksController < ApplicationController
-      before_action :set_wordbook, only: [:show, :update, :destroy]
+      before_action :set_wordbook, only: [ :show, :update, :destroy ]
 
       def index
         wordbooks = Wordbook.all

--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class WordsController < ApplicationController
-      before_action :set_word, only: [:show, :update, :destroy]
+      before_action :set_word, only: [ :show, :update, :destroy ]
 
       def index
         words = Word.all

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -6,5 +6,5 @@ class Word < ApplicationRecord
   validates :spelling, presence: true
   validates :status, presence: true
 
-  enum :status, { learning: 'learning', learned: 'learned' }
+  enum :status, { learning: "learning", learned: "learned" }
 end

--- a/db/migrate/20260217134142_update_users_schema_to_match_er_diagram.rb
+++ b/db/migrate/20260217134142_update_users_schema_to_match_er_diagram.rb
@@ -2,14 +2,14 @@ class UpdateUsersSchemaToMatchErDiagram < ActiveRecord::Migration[8.1]
   def change
     # google_id を provider_uid にリネーム
     rename_column :users, :google_id, :provider_uid
-    
+
     # provider カラムを追加（必須）
-    add_column :users, :provider, :string, null: false, default: 'google'
-    
+    add_column :users, :provider, :string, null: false, default: "google"
+
     # guest_expires_at カラムを追加
     add_column :users, :guest_expires_at, :datetime
-    
+
     # デフォルト値を削除（既存データに適用済み）
-    change_column_default :users, :provider, from: 'google', to: nil
+    change_column_default :users, :provider, from: "google", to: nil
   end
 end

--- a/db/migrate/20260219142721_add_unique_index_to_users_provider_and_provider_uid.rb
+++ b/db/migrate/20260219142721_add_unique_index_to_users_provider_and_provider_uid.rb
@@ -1,5 +1,5 @@
 class AddUniqueIndexToUsersProviderAndProviderUid < ActiveRecord::Migration[8.1]
   def change
-    add_index :users, [:provider, :provider_uid], unique: true, name: 'index_users_on_provider_and_provider_uid'
+    add_index :users, [ :provider, :provider_uid ], unique: true, name: "index_users_on_provider_and_provider_uid"
   end
 end


### PR DESCRIPTION
## Summary

Fix RuboCop offenses detected by the CI lint check.

- **`Layout/SpaceInsideArrayLiteralBrackets`**: Added spaces inside array brackets in `before_action` calls across controllers and in `add_index` in migration
- **`Style/StringLiterals`**: Replaced single-quoted strings with double-quoted strings in `word.rb` enum definition
- **`Layout/TrailingWhitespace`**: Removed trailing whitespace from blank lines in migration file