### PR TITLE
Change settings intervals to interval type and next_review_date to datetime

### DIFF
--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -5,26 +5,26 @@ module Api
 
       def index
         settings = Setting.all
-        render json: settings
+        render json: settings.map { |s| setting_response(s) }
       end
 
       def show
-        render json: @setting
+        render json: setting_response(@setting)
       end
 
       def create
-        setting = Setting.new(setting_params)
+        setting = Setting.new(build_setting_params)
 
         if setting.save
-          render json: setting, status: :created
+          render json: setting_response(setting), status: :created
         else
           render json: { errors: setting.errors.full_messages }, status: :unprocessable_entity
         end
       end
 
       def update
-        if @setting.update(setting_params)
-          render json: @setting
+        if @setting.update(build_setting_params)
+          render json: setting_response(@setting)
         else
           render json: { errors: @setting.errors.full_messages }, status: :unprocessable_entity
         end
@@ -42,7 +42,52 @@ module Api
       end
 
       def setting_params
-        params.require(:setting).permit(:user_id, :hard_interval_days, :uncertain_interval_days, :easy_interval_days)
+        params.require(:setting).permit(
+          :user_id,
+          hard_interval: [ :days, :hours, :minutes ],
+          uncertain_interval: [ :days, :hours, :minutes ],
+          easy_interval: [ :days, :hours, :minutes ]
+        )
+      end
+
+      def build_setting_params
+        permitted = setting_params
+        result = permitted.slice(:user_id).to_h
+
+        %i[hard_interval uncertain_interval easy_interval].each do |attr|
+          next unless permitted[attr]
+
+          result[attr] = interval_to_duration(permitted[attr])
+        end
+
+        result
+      end
+
+      def interval_to_duration(hash)
+        days = hash[:days].to_i
+        hours = hash[:hours].to_i
+        minutes = hash[:minutes].to_i
+
+        days.days + hours.hours + minutes.minutes
+      end
+
+      def setting_response(setting)
+        setting.as_json(except: %i[hard_interval uncertain_interval easy_interval]).merge(
+          hard_interval: duration_to_hash(setting.hard_interval),
+          uncertain_interval: duration_to_hash(setting.uncertain_interval),
+          easy_interval: duration_to_hash(setting.easy_interval)
+        )
+      end
+
+      def duration_to_hash(duration)
+        return nil if duration.blank?
+
+        total_seconds = duration.to_i
+        days = total_seconds / 86400
+        hours = (total_seconds % 86400) / 3600
+        minutes = (total_seconds % 3600) / 60
+
+        { days: days, hours: hours, minutes: minutes }
       end
     end
   end

--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -42,7 +42,7 @@ module Api
       end
 
       def word_params
-        params.require(:word).permit(:wordbook_id, :spelling, :status, :next_review_date)
+        params.require(:word).permit(:wordbook_id, :spelling, :status, :next_review_at)
       end
     end
   end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,7 +1,19 @@
 class Setting < ApplicationRecord
   belongs_to :user
 
-  validates :hard_interval_days, presence: true, numericality: { only_integer: true, greater_than: 0 }
-  validates :uncertain_interval_days, presence: true, numericality: { only_integer: true, greater_than: 0 }
-  validates :easy_interval_days, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :hard_interval, :uncertain_interval, :easy_interval, presence: true
+  validate :intervals_must_be_positive
+
+  private
+
+  def intervals_must_be_positive
+    %i[hard_interval uncertain_interval easy_interval].each do |attr|
+      value = send(attr)
+      next if value.blank?
+
+      unless value.is_a?(ActiveSupport::Duration) && value.to_i > 0
+        errors.add(attr, "must be a positive interval")
+      end
+    end
+  end
 end

--- a/db/migrate/20260226141209_change_intervals_to_interval_type.rb
+++ b/db/migrate/20260226141209_change_intervals_to_interval_type.rb
@@ -1,0 +1,51 @@
+class ChangeIntervalsToIntervalType < ActiveRecord::Migration[8.1]
+  def up
+    # settings: integer -> interval type
+    add_column :settings, :hard_interval, :interval
+    add_column :settings, :uncertain_interval, :interval
+    add_column :settings, :easy_interval, :interval
+
+    execute <<~SQL
+      UPDATE settings
+      SET hard_interval = make_interval(days => hard_interval_days),
+          uncertain_interval = make_interval(days => uncertain_interval_days),
+          easy_interval = make_interval(days => easy_interval_days)
+    SQL
+
+    change_column_null :settings, :hard_interval, false
+    change_column_null :settings, :uncertain_interval, false
+    change_column_null :settings, :easy_interval, false
+    remove_column :settings, :hard_interval_days
+    remove_column :settings, :uncertain_interval_days
+    remove_column :settings, :easy_interval_days
+
+    # words: date -> datetime, rename next_review_date -> next_review_at
+    rename_column :words, :next_review_date, :next_review_at
+    change_column :words, :next_review_at, :datetime
+  end
+
+  def down
+    # words: datetime -> date
+    change_column :words, :next_review_at, :date
+    rename_column :words, :next_review_at, :next_review_date
+
+    # settings: interval -> integer
+    add_column :settings, :hard_interval_days, :integer
+    add_column :settings, :uncertain_interval_days, :integer
+    add_column :settings, :easy_interval_days, :integer
+
+    execute <<~SQL
+      UPDATE settings
+      SET hard_interval_days = EXTRACT(EPOCH FROM hard_interval) / 86400,
+          uncertain_interval_days = EXTRACT(EPOCH FROM uncertain_interval) / 86400,
+          easy_interval_days = EXTRACT(EPOCH FROM easy_interval) / 86400
+    SQL
+
+    change_column_null :settings, :hard_interval_days, false
+    change_column_null :settings, :uncertain_interval_days, false
+    change_column_null :settings, :easy_interval_days, false
+    remove_column :settings, :hard_interval
+    remove_column :settings, :uncertain_interval
+    remove_column :settings, :easy_interval
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_22_131840) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_26_141209) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -35,9 +35,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_22_131840) do
 
   create_table "settings", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.integer "easy_interval_days", null: false
-    t.integer "hard_interval_days", null: false
-    t.integer "uncertain_interval_days", null: false
+    t.interval "easy_interval", null: false
+    t.interval "hard_interval", null: false
+    t.interval "uncertain_interval", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_settings_on_user_id"
@@ -67,7 +67,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_22_131840) do
 
   create_table "words", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.date "next_review_date"
+    t.datetime "next_review_at"
     t.string "spelling", null: false
     t.string "status", null: false
     t.datetime "updated_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,16 +30,16 @@ user2 = User.create!(
 puts "Creating settings..."
 Setting.create!(
   user: user1,
-  hard_interval_days: 1,
-  uncertain_interval_days: 3,
-  easy_interval_days: 7
+  hard_interval: 1.day,
+  uncertain_interval: 3.days,
+  easy_interval: 7.days
 )
 
 Setting.create!(
   user: user2,
-  hard_interval_days: 2,
-  uncertain_interval_days: 5,
-  easy_interval_days: 10
+  hard_interval: 2.days,
+  uncertain_interval: 5.days,
+  easy_interval: 10.days
 )
 
 puts "Creating wordbooks..."
@@ -63,21 +63,21 @@ word1 = Word.create!(
   wordbook: wordbook1,
   spelling: "apple",
   status: "learning",
-  next_review_date: Date.today + 1
+  next_review_at: Time.current + 1.day
 )
 
 word2 = Word.create!(
   wordbook: wordbook1,
   spelling: "book",
   status: "learning",
-  next_review_date: Date.today + 3
+  next_review_at: Time.current + 3.days
 )
 
 word3 = Word.create!(
   wordbook: wordbook2,
   spelling: "negotiate",
   status: "learning",
-  next_review_date: Date.today + 2
+  next_review_at: Time.current + 2.days
 )
 
 puts "Creating meanings..."


### PR DESCRIPTION
## Summary

- Change settings columns `hard_interval_days`, `uncertain_interval_days`, `easy_interval_days` (integer) to PostgreSQL `interval` type (`hard_interval`, `uncertain_interval`, `easy_interval`)
- Rename and change words `next_review_date` (date) to `next_review_at` (datetime)
- Update Settings API request/response to use `{ days, hours, minutes }` format

## Background

Settings intervals are currently stored as integers (days only). To allow users to configure intervals at day/hour/minute granularity, we migrate to PostgreSQL's `interval` type. The words `next_review_date` is also changed to `datetime` to support time-precise review scheduling.

## Changes

| File | Description |
|------|-------------|
| `db/migrate/..._change_intervals_to_interval_type.rb` | Migration with existing data conversion (reversible) |
| `app/models/setting.rb` | Replace numericality with custom interval validation |
| `app/controllers/api/v1/settings_controller.rb` | Accept `{ days, hours, minutes }` params, convert to Duration, format response |
| `app/controllers/api/v1/words_controller.rb` | `next_review_date` → `next_review_at` in permitted params |
| `db/seeds.rb` | Update for interval / datetime values |
| `db/schema.rb` | Auto-generated |