### PR TITLE
Update word status enum and add DB check constraint

### DIFF
--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -6,5 +6,5 @@ class Word < ApplicationRecord
   validates :spelling, presence: true
   validates :status, presence: true
 
-  enum :status, { learning: "learning", learned: "learned" }
+  enum :status, { not_studied: "not_studied", hard: "hard", uncertain: "uncertain", easy: "easy" }
 end

--- a/db/migrate/20260227024502_add_check_constraint_to_words_status.rb
+++ b/db/migrate/20260227024502_add_check_constraint_to_words_status.rb
@@ -1,0 +1,15 @@
+class AddCheckConstraintToWordsStatus < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL
+      UPDATE words SET status = 'not_studied' WHERE status NOT IN ('not_studied', 'hard', 'uncertain', 'easy')
+    SQL
+
+    add_check_constraint :words,
+      "status IN ('not_studied', 'hard', 'uncertain', 'easy')",
+      name: "check_words_status_values"
+  end
+
+  def down
+    remove_check_constraint :words, name: "check_words_status_values"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_26_141209) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_27_024502) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -73,6 +73,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_26_141209) do
     t.datetime "updated_at", null: false
     t.bigint "wordbook_id", null: false
     t.index ["wordbook_id"], name: "index_words_on_wordbook_id"
+    t.check_constraint "status::text = ANY (ARRAY['not_studied'::character varying, 'hard'::character varying, 'uncertain'::character varying, 'easy'::character varying]::text[])", name: "check_words_status_values"
   end
 
   add_foreign_key "examples", "words"


### PR DESCRIPTION
## Summary

Align the `Word#status` enum with the requirements defined in `docs/requirements.md` and add a DB-level check constraint for data integrity.

## Changes

- Update `Word#status` enum from `learning/learned` to `not_studied/hard/uncertain/easy` to match the requirements in `docs/requirements.md`
- Add DB-level check constraint (`check_words_status_values`) to ensure only valid status values are stored
- Migration includes data migration to convert existing invalid status values to `not_studied`

## Verification

Both model-level and DB-level constraints are working:
- **Model**: `ArgumentError` is raised for invalid status values
- **DB**: `PG::CheckViolation` is raised for direct SQL inserts with invalid values