### PR TITLE
Add provider enum and DB check constraint to users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,6 @@ class User < ApplicationRecord
   validates :provider, presence: true
   validates :provider_uid, presence: true, uniqueness: { scope: :provider }
   validates :guest_expires_at, presence: true, if: -> { provider == "guest" }
+
+  enum :provider, { google: "google", guest: "guest" }
 end

--- a/db/migrate/20260227121940_add_check_constraint_to_users_provider.rb
+++ b/db/migrate/20260227121940_add_check_constraint_to_users_provider.rb
@@ -1,0 +1,7 @@
+class AddCheckConstraintToUsersProvider < ActiveRecord::Migration[8.1]
+  def change
+    add_check_constraint :users,
+      "provider IN ('google', 'guest')",
+      name: "check_users_provider_values"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_27_024502) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_27_121940) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_27_024502) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "provider_uid"], name: "index_users_on_provider_and_provider_uid", unique: true
     t.check_constraint "provider::text <> 'guest'::text OR guest_expires_at IS NOT NULL", name: "check_guest_expires_at_presence"
+    t.check_constraint "provider::text = ANY (ARRAY['google'::character varying, 'guest'::character varying]::text[])", name: "check_users_provider_values"
   end
 
   create_table "wordbooks", force: :cascade do |t|


### PR DESCRIPTION
## Summary

Add model-level enum and DB-level check constraint for `User#provider` to ensure only valid provider values (`google`, `guest`) are stored.

## Changes

- Add `enum :provider` to `User` model to restrict values to `google` and `guest`
- Add DB check constraint (`check_users_provider_values`) to enforce valid provider values at the database level

## Verification

Both model-level and DB-level constraints are working:
- **Normal**: `google` and `guest` providers are saved successfully
- **Model**: `ArgumentError` is raised for invalid provider values (e.g. `apple`, `facebook`)
- **DB**: `PG::CheckViolation` is raised for direct SQL inserts with invalid values