### PR TITLE
Simplify CLAUDE.md and update requirements schema details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,55 +1,26 @@
-# CLAUDE.md
+# Overview
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+WordBeetle API is the backend for a spaced-repetition vocabulary learning app.
 
-## Commands
+## Tech Stack
 
-```bash
-# Setup
-bin/setup                    # Install gems, prepare database
+- Ruby on Rails 8.1 (API-only mode)
+- PostgreSQL
+- Authentication: Google ID token verification (`googleauth` gem)
+- Testing: RSpec, FactoryBot, shoulda-matchers
+- Linting: rubocop-rails-omakase (TODO: Hooks導入後に削除)
 
-# Development
-bin/dev                      # Start development server
+## Project Structure
 
-# Testing
-bin/rails test               # Run all tests
-bin/rails test test/models/user_test.rb  # Run a single test file
+- `app/controllers/api/v1/` — All API endpoints are namespaced under `Api::V1`
 
-# Linting & Security
-bin/rubocop                  # Lint Ruby code (Rails Omakase style)
-bin/brakeman                 # Security vulnerability scan
-bin/bundler-audit            # Dependency vulnerability audit
+## Reference Documents
 
-# Full CI pipeline
-bin/ci                       # Setup, lint, audit, test, seed
+Read these as needed based on the task.
 
-# Database
-bin/rails db:migrate         # Run pending migrations
-bin/rails db:seed:replant    # Reset and re-seed data
-```
+- `docs/requirements.md` — Feature requirements and priorities (P0/P1/P2). Currently working on P0 items.
+- `docs/er_diagram.plantuml` — Database ER diagram
 
-## Architecture
+## Communication
 
-WordBeetle API is a **Rails 8.1 API-only** (no views) application for a spaced-repetition vocabulary learning app. Deployed via Kamal with Docker.
-
-### API Structure
-
-All endpoints are namespaced under `/api/v1/`. The single auth endpoint is `POST /api/v1/auth/google` for Google OAuth ID token verification. Resources follow standard Rails REST conventions: `wordbooks`, `words`, `meanings`, `examples`, `settings`.
-
-### Authentication Flow
-
-- **Google OAuth**: Client sends a Google ID token; the server verifies it via `Google::Auth::IDTokens.verify_oidc` (see `app/controllers/concerns/google_authenticatable.rb`) using `GOOGLE_CLIENT_ID` from environment.
-- **Guest users**: Users with `provider: "guest"` must have `guest_expires_at` set (enforced at both model validation and DB check constraint level).
-- Users are identified by `(provider, provider_uid)` — unique at DB level. Email has a separate unique index but can be nil.
-
-### Data Model
-
-- `User` → has_many `Wordbook` → has_many `Word` → has_many `Meaning`, has_many `Example`
-- `User` → has_one `Setting` (stores SRS interval days: hard/uncertain/easy)
-- Words have a `status` field (`learning`/`learned`) and `next_review_date` for spaced repetition scheduling.
-
-### Key Conventions
-
-- **Three databases**: primary (app data), cache (Solid Cache), queue (Solid Queue) — all PostgreSQL.
-- Migrations use timestamped filenames. Recent migrations added DB-level constraints for user provider integrity.
-- `docs/requirements.md` contains prioritized (P0/P1/P2) feature requirements across 8 development phases — consult it before adding features.
+- Respond in Japanese

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -353,11 +353,16 @@ WordBeetleは、効率的な単語学習を実現する間隔反復学習機能�
 
 #### Users（ユーザ）
 
+- `(provider, provider_uid)` の組み合わせで一意に識別（DBユニーク制約）
+- `provider` は `google` または `guest` のみ（DBチェック制約）。今後、他の認証プロバイダ（GitHub、Apple等）が追加される可能性あり
+- `guest` ユーザは `guest_expires_at` が必須（モデルバリデーション＋DBチェック制約）
+- `email` はユニーク制約あり（nilを許容）
+
 - [P0] id
 - [P0] email
 - [P0] name
 - [P0] avatar_url
-- [P0] provider（google / github / guestなど）
+- [P0] provider（google / guest）
 - [P0] provider_uid（ゲストユーザの識別子も含む）
 - [P0] guest_expires_at（ゲストユーザの有効期限）
 - [P0] created_at
@@ -376,13 +381,16 @@ WordBeetleは、効率的な単語学習を実現する間隔反復学習機能�
 
 #### Words（単語）
 
+- `status` と `next_review_at` はSRS（間隔反復学習）のスケジューリングに使用する
+- `status` は `not_studied` / `hard` / `uncertain` / `easy` の4値（DBチェック制約）
+
 - [P0] id
 - [P0] wordbook_id
 - [P0] spelling
 - [P2] pronunciation
 - [P2] part_of_speech
 - [P0] status（not_studied / hard / uncertain / easy）
-- [P0] next_review_date
+- [P0] next_review_at
 - [P2] image_url
 - [P2] memo
 - [P0] created_at
@@ -421,11 +429,14 @@ WordBeetleは、効率的な単語学習を実現する間隔反復学習機能�
 
 #### Settings（ユーザ設定）
 
+- SRSの復習間隔を `hard` / `uncertain` / `easy` ごとに保持する
+- interval カラムは PostgreSQL の interval 型を使用
+
 - [P0] id
 - [P0] user_id
-- [P0] hard_interval_days
-- [P0] uncertain_interval_days
-- [P0] easy_interval_days
+- [P0] hard_interval
+- [P0] uncertain_interval
+- [P0] easy_interval
 - [P2] notification_enabled
 - [P2] notification_time
 - [P2] voice_language（us / uk）


### PR DESCRIPTION
## Summary

- Simplify `CLAUDE.md` to focus on overview, tech stack, project structure, and reference docs
- Add DB constraint documentation to `docs/requirements.md` (Users, Words, Settings)
- Rename columns: `next_review_date` → `next_review_at`, `*_interval_days` → `*_interval`
- Update `provider` values to reflect current implementation (`google` / `guest`)
