### PR TITLE
Update CLAUDE.md, commit command, and add rubocop hook

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -36,7 +36,8 @@ Based on the above changes:
 ### 2. Commit and push
 
 - Stage the relevant changed files with `git add`
-- Create a single commit with a clear message in English derived from the diff
+- Create a single commit with a short, simple message in English derived from the diff
+- Do NOT include `Co-Authored-By` or any AI attribution in the commit message
 - Push the branch to origin (`git push -u origin <branch-name>`)
 
 ### 3. Create pull request

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'file=$(jq -r \".tool_input.file_path\"); if [[ \"$file\" == *.rb ]]; then bin/rubocop -a \"$file\" >/dev/null 2>&1; result=$(bin/rubocop \"$file\" 2>&1); if [ $? -ne 0 ]; then echo \"$result\" >&2; exit 2; fi; fi'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,6 @@ WordBeetle API is the backend for a spaced-repetition vocabulary learning app.
 - PostgreSQL
 - Authentication: Google ID token verification (`googleauth` gem)
 - Testing: RSpec, FactoryBot, shoulda-matchers
-- Linting: rubocop-rails-omakase (TODO: Hooks導入後に削除)
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary

- Remove outdated linting note from CLAUDE.md (rubocop hook is now configured)
- Update commit-push-pr command: use short/simple commit messages, no AI attribution
- Add `.claude/settings.json` with PostToolUse hook for auto-running rubocop on `.rb` files
