### PR TITLE
Update seed word statuses to match new status enum values

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -62,21 +62,21 @@ puts "Creating words..."
 word1 = Word.create!(
   wordbook: wordbook1,
   spelling: "apple",
-  status: "learning",
+  status: "hard",
   next_review_at: Time.current + 1.day
 )
 
 word2 = Word.create!(
   wordbook: wordbook1,
   spelling: "book",
-  status: "learning",
+  status: "uncertain",
   next_review_at: Time.current + 3.days
 )
 
 word3 = Word.create!(
   wordbook: wordbook2,
   spelling: "negotiate",
-  status: "learning",
+  status: "not_studied",
   next_review_at: Time.current + 2.days
 )
 


### PR DESCRIPTION
## Summary

- Update seed data word statuses from deprecated `learning` to new enum values (`hard`, `uncertain`, `not_studied`)

## Test plan

- [x] Run `rails db:seed` and verify words are created with correct statuses
