### PR TITLE
Add guest authentication endpoint

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -2,6 +2,15 @@ module Api
   module V1
     class AuthController < ApplicationController
       include GoogleAuthenticatable
+      include GuestAuthenticatable
+
+      def guest
+        provider_uid = SecureRandom.uuid
+        user = User.create!(provider: "guest", provider_uid: provider_uid, guest_expires_at: 7.days.from_now)
+        token = generate_guest_token(provider_uid)
+
+        render json: { user: user, token: token }, status: :created
+      end
 
       def google
         id_token = request.headers["Authorization"]&.split("Bearer ")&.last

--- a/app/controllers/concerns/guest_authenticatable.rb
+++ b/app/controllers/concerns/guest_authenticatable.rb
@@ -1,0 +1,21 @@
+module GuestAuthenticatable
+  extend ActiveSupport::Concern
+
+  private
+
+  def generate_guest_token(provider_uid)
+    guest_verifier.generate(provider_uid, purpose: :guest_auth)
+  end
+
+  def verify_guest_token(token)
+    guest_verifier.verify(token, purpose: :guest_auth)
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    nil
+  end
+
+  def guest_verifier
+    @guest_verifier ||= ActiveSupport::MessageVerifier.new(
+      Rails.application.key_generator.generate_key("guest_auth")
+    )
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       # Authentication
+      post "auth/guest", to: "auth#guest"
       post "auth/google", to: "auth#google"
 
       # Resources

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -1,6 +1,40 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Auth", type: :request do
+  describe "POST /api/v1/auth/guest" do
+    it "creates a guest user and returns 201 with user and token" do
+      expect {
+        post "/api/v1/auth/guest"
+      }.to change(User, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+
+      body = response.parsed_body
+      expect(body["user"]["provider"]).to eq("guest")
+      expect(body["token"]).to be_present
+    end
+
+    it "sets guest_expires_at to approximately 7 days from now" do
+      post "/api/v1/auth/guest"
+
+      user = User.last
+      expect(user.guest_expires_at).to be_within(1.second).of(7.days.from_now)
+    end
+
+    it "returns a token that can be verified" do
+      post "/api/v1/auth/guest"
+
+      body = response.parsed_body
+      token = body["token"]
+      provider_uid = body["user"]["provider_uid"]
+
+      verifier = ActiveSupport::MessageVerifier.new(
+        Rails.application.key_generator.generate_key("guest_auth")
+      )
+      expect(verifier.verify(token, purpose: :guest_auth)).to eq(provider_uid)
+    end
+  end
+
   describe "POST /api/v1/auth/google" do
     let(:google_payload) do
       {


### PR DESCRIPTION
## Summary

Add guest authentication to allow users to try the app without signing in with Google.

- Add `POST /api/v1/auth/guest` endpoint that creates a temporary guest user and returns a signed token
- Create `GuestAuthenticatable` concern that handles guest token generation and verification using `ActiveSupport::MessageVerifier` with a `guest_auth` purpose
- Guest users are created with `provider: "guest"`, a random UUID as `provider_uid`, and `guest_expires_at` set to 7 days from creation
- The returned token is a signed message containing the `provider_uid`, which can be verified server-side for subsequent requests

## Changes

### New files
- `app/controllers/concerns/guest_authenticatable.rb` — Concern providing `generate_guest_token` and `verify_guest_token` methods using `ActiveSupport::MessageVerifier`

### Modified files
- `app/controllers/api/v1/auth_controller.rb` — Include `GuestAuthenticatable` and add `guest` action
- `config/routes.rb` — Add `POST /api/v1/auth/guest` route
- `spec/requests/api/v1/auth_spec.rb` — Add request specs covering user creation, expiration time, and token verification

## Test plan

- [x] Run `bundle exec rspec spec/requests/api/v1/auth_spec.rb` to verify all guest auth specs pass
- [x] Verify existing Google auth specs still pass (`bundle exec rspec`)
- [x] Manual test: `POST /api/v1/auth/guest` returns 201 with user and token in response body
