### PR TITLE
Restrict user fields in auth response serialization

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -9,7 +9,7 @@ module Api
         user = User.create!(provider: "guest", provider_uid: provider_uid, guest_expires_at: 7.days.from_now)
         token = generate_guest_token(provider_uid)
 
-        render json: { user: user, token: token }, status: :created
+        render json: { user: user.as_json(only: [ :guest_expires_at ]), token: token }, status: :created
       end
 
       def google
@@ -36,7 +36,7 @@ module Api
           u.avatar_url = payload["picture"]
         end
 
-        render json: { user: user }, status: :ok
+        render json: { user: user.as_json(only: [ :email, :name, :avatar_url ]) }, status: :ok
       end
     end
   end

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -24,7 +24,12 @@ paths:
                 type: object
                 properties:
                   user:
-                    $ref: "#/components/schemas/User"
+                    type: object
+                    properties:
+                      guest_expires_at:
+                        type: string
+                        format: date-time
+                        description: Expiration time for the guest user (7 days after creation)
                   token:
                     type: string
                     description: Signed guest token for subsequent requests
@@ -47,7 +52,16 @@ paths:
                 type: object
                 properties:
                   user:
-                    $ref: "#/components/schemas/User"
+                    type: object
+                    properties:
+                      email:
+                        type: string
+                      name:
+                        type: string
+                        nullable: true
+                      avatar_url:
+                        type: string
+                        nullable: true
         "400":
           description: Authorization header missing
           content:

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "Api::V1::Auth", type: :request do
       expect(response).to have_http_status(:created)
 
       body = response.parsed_body
-      expect(body["user"]["provider"]).to eq("guest")
+      expect(body["user"]).to have_key("guest_expires_at")
+      expect(body["user"].keys).to match_array([ "guest_expires_at" ])
       expect(body["token"]).to be_present
     end
 
@@ -26,7 +27,7 @@ RSpec.describe "Api::V1::Auth", type: :request do
 
       body = response.parsed_body
       token = body["token"]
-      provider_uid = body["user"]["provider_uid"]
+      provider_uid = User.last.provider_uid
 
       verifier = ActiveSupport::MessageVerifier.new(
         Rails.application.key_generator.generate_key("guest_auth")
@@ -80,7 +81,12 @@ RSpec.describe "Api::V1::Auth", type: :request do
         }.to change(User, :count).by(1)
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body["user"]["email"]).to eq("test@example.com")
+
+        user_json = response.parsed_body["user"]
+        expect(user_json["email"]).to eq("test@example.com")
+        expect(user_json["name"]).to eq("Test User")
+        expect(user_json["avatar_url"]).to eq("https://example.com/avatar.jpg")
+        expect(user_json.keys).to match_array([ "email", "name", "avatar_url" ])
       end
     end
 


### PR DESCRIPTION
## Summary

- Restrict user object fields in auth API responses to only return necessary attributes
  - Guest auth (`POST /auth/guest`): returns only `guest_expires_at`
  - Google auth (`POST /auth/google`): returns only `email`, `name`, `avatar_url`
- Update OpenAPI spec to reflect the new inline response schemas
- Update request specs to verify exact response shape

## Test plan

- [x] Run `bundle exec rspec spec/requests/api/v1/auth_spec.rb` and verify all tests pass
- [x] Verify guest auth response only contains `guest_expires_at` in user object
- [x] Verify Google auth response only contains `email`, `name`, `avatar_url` in user object
