### PR TITLE
Make provider_uid nullable for guest users

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -6,8 +6,7 @@ module Api
       skip_before_action :authenticate_user!
 
       def guest
-        provider_uid = SecureRandom.uuid
-        user = User.create!(provider: "guest", provider_uid: provider_uid, guest_expires_at: 7.days.from_now)
+        user = User.create!(provider: "guest", guest_expires_at: 7.days.from_now)
         token = encode_jwt(user.id, expires_at: user.guest_expires_at)
 
         render json: { user: user.as_json(only: [ :guest_expires_at ]), token: token }, status: :created

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
 
   validates :email, uniqueness: { allow_nil: true }
   validates :provider, presence: true
-  validates :provider_uid, presence: true, uniqueness: { scope: :provider }
+  validates :provider_uid, presence: true, uniqueness: { scope: :provider }, unless: -> { guest? }
   validates :guest_expires_at, presence: true, if: -> { provider == "guest" }
 
   enum :provider, { google: "google", guest: "guest" }

--- a/db/migrate/20260320122208_make_provider_uid_nullable_for_guests.rb
+++ b/db/migrate/20260320122208_make_provider_uid_nullable_for_guests.rb
@@ -1,0 +1,22 @@
+class MakeProviderUidNullableForGuests < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :users, :provider_uid, true
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          ALTER TABLE users
+            ADD CONSTRAINT chk_provider_uid_required_for_non_guest
+            CHECK (provider = 'guest' OR provider_uid IS NOT NULL)
+        SQL
+      end
+
+      dir.down do
+        execute <<~SQL
+          ALTER TABLE users
+            DROP CONSTRAINT chk_provider_uid_required_for_non_guest
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_27_121940) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_20_122208) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -50,11 +50,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_27_121940) do
     t.datetime "guest_expires_at"
     t.string "name"
     t.string "provider", null: false
-    t.string "provider_uid", null: false
+    t.string "provider_uid"
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "provider_uid"], name: "index_users_on_provider_and_provider_uid", unique: true
     t.check_constraint "provider::text <> 'guest'::text OR guest_expires_at IS NOT NULL", name: "check_guest_expires_at_presence"
+    t.check_constraint "provider::text = 'guest'::text OR provider_uid IS NOT NULL", name: "chk_provider_uid_required_for_non_guest"
     t.check_constraint "provider::text = ANY (ARRAY['google'::character varying, 'guest'::character varying]::text[])", name: "check_users_provider_values"
   end
 

--- a/docs/er_diagram.plantuml
+++ b/docs/er_diagram.plantuml
@@ -12,7 +12,7 @@ entity "users" as users {
   name : string
   avatar_url : string
   *provider : string
-  *provider_uid : string
+  provider_uid : string
   guest_expires_at : datetime
   created_at : datetime
   updated_at : datetime

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -773,6 +773,7 @@ components:
           enum: [google, guest]
         provider_uid:
           type: string
+          nullable: true
         email:
           type: string
           nullable: true

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
 
     trait :guest do
       provider { "guest" }
+      provider_uid { nil }
       email { nil }
       name { nil }
       guest_expires_at { 30.days.from_now }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,9 +10,21 @@ RSpec.describe User, type: :model do
     subject { build(:user) }
 
     it { is_expected.to validate_presence_of(:provider) }
-    it { is_expected.to validate_presence_of(:provider_uid) }
     it { is_expected.to validate_uniqueness_of(:email).allow_nil }
-    it { is_expected.to validate_uniqueness_of(:provider_uid).scoped_to(:provider) }
+
+    context "when provider is google" do
+      subject { build(:user, provider: "google") }
+
+      it { is_expected.to validate_presence_of(:provider_uid) }
+      it { is_expected.to validate_uniqueness_of(:provider_uid).scoped_to(:provider) }
+    end
+
+    context "when provider is guest" do
+      it "does not require provider_uid" do
+        user = build(:user, :guest, provider_uid: nil)
+        expect(user).to be_valid
+      end
+    end
   end
 
   describe "enum" do

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "Api::V1::Auth", type: :request do
     context "when email is already registered with a different provider" do
       before do
         allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return(google_payload)
-        create(:user, :guest, provider_uid: "guest_uid_999", email: "test@example.com")
+        create(:user, :guest, email: "test@example.com")
       end
 
       it "returns conflict" do


### PR DESCRIPTION
## Summary

- Make `provider_uid` nullable so guest users no longer need a dummy UUID value
- Add a PostgreSQL CHECK constraint (`provider = 'guest' OR provider_uid IS NOT NULL`) to enforce `provider_uid` for all non-guest providers at the DB level
- Remove `SecureRandom.uuid` generation from the guest auth action
- Update User model validation to skip `provider_uid` for guests
- Update tests and docs (ER diagram, OpenAPI spec) accordingly

## Motivation

After JWT authentication was introduced, guest users' `provider_uid` (a random UUID) is never referenced. Removing it simplifies guest creation and makes the schema more accurate about what is actually required.

## Test plan

- [x] `bin/rails db:migrate` succeeds
- [x] `bundle exec rspec` — all 115 tests pass
- [x] Verify `POST /api/v1/auth/guest` creates a user with `provider_uid = NULL`
- [x] Verify `POST /api/v1/auth/google` still sets `provider_uid` from Google payload
