### PR TITLE
Add guest-to-Google migration for data transfer on registration

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class AuthController < ApplicationController
       include GoogleAuthenticatable
+      include GuestMigratable
 
       skip_before_action :authenticate_user!
 
@@ -21,6 +22,10 @@ module Api
 
         return render json: { error: "Invalid ID token" }, status: :unauthorized unless payload
 
+        if params[:guest_token].present?
+          return handle_guest_migration(payload)
+        end
+
         email = payload["email"]
         existing_user = User.find_by(email: email) if email.present?
 
@@ -37,6 +42,21 @@ module Api
         end
 
         render json: { user: user.as_json(only: [ :email, :name, :avatar_url ]), token: encode_jwt(user.id) }, status: :ok
+      end
+      private
+
+      def handle_guest_migration(google_payload)
+        guest_user = find_guest_user_from_token(params[:guest_token])
+
+        return render json: { error: "Invalid guest token" }, status: :unauthorized unless guest_user
+
+        result = migrate_guest_to_google(guest_user, google_payload)
+
+        if result[:success]
+          render json: { user: result[:user].as_json(only: [ :email, :name, :avatar_url ]), token: encode_jwt(result[:user].id) }, status: :ok
+        else
+          render json: { error: result[:error] }, status: :unprocessable_entity
+        end
       end
     end
   end

--- a/app/controllers/concerns/guest_migratable.rb
+++ b/app/controllers/concerns/guest_migratable.rb
@@ -1,0 +1,51 @@
+module GuestMigratable
+  extend ActiveSupport::Concern
+
+  private
+
+  def find_guest_user_from_token(token)
+    payload = decode_jwt(token)
+    return nil unless payload
+
+    User.find_by(id: payload["sub"], provider: "guest")
+  end
+
+  def migrate_guest_to_google(guest_user, google_payload)
+    return { success: false, user: nil, error: "User is not a guest" } unless guest_user.guest?
+
+    ActiveRecord::Base.transaction do
+      existing_google_user = User.find_by(provider: "google", provider_uid: google_payload["sub"])
+
+      if existing_google_user
+        merge_guest_into_google_user(guest_user, existing_google_user)
+      else
+        convert_guest_to_google(guest_user, google_payload)
+      end
+    end
+  end
+
+  def convert_guest_to_google(guest_user, google_payload)
+    guest_user.update!(
+      provider: "google",
+      provider_uid: google_payload["sub"],
+      email: google_payload["email"],
+      name: google_payload["name"],
+      avatar_url: google_payload["picture"],
+      guest_expires_at: nil
+    )
+
+    { success: true, user: guest_user, error: nil }
+  end
+
+  def merge_guest_into_google_user(guest_user, google_user)
+    guest_user.wordbooks.update_all(user_id: google_user.id)
+
+    if guest_user.setting.present? && google_user.setting.blank?
+      guest_user.setting.update!(user_id: google_user.id)
+    end
+
+    guest_user.reload.destroy!
+
+    { success: true, user: google_user, error: nil }
+  end
+end

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -37,6 +37,35 @@
 
 ゲスト認証のJWT有効期限は、ユーザーレコードの`guest_expires_at`と同一の値を使用。これによりDBとトークンの有効期限が一致することを保証。
 
+## ゲストユーザーデータの引き継ぎ（移行）
+
+ゲストユーザーが Google 認証で本登録する際、`POST /api/v1/auth/google` に `guest_token` パラメータを付与することでデータを引き継ぐ。
+
+```
+[クライアント] --Bearer Google ID Token + body { guest_token: JWT }--> POST /api/v1/auth/google --> [移行 + JWT発行]
+```
+
+### フロー
+
+1. クライアントが Google ID token を `Authorization: Bearer <id_token>` で送信（通常と同じ）
+2. リクエストボディに `{ "guest_token": "<guest_jwt>" }` を含める
+3. サーバーが Google ID token を検証し、guest_token から対象ゲストユーザーを特定
+4. 移行処理を実行し、新しい JWT を返却
+
+### 2つのシナリオ
+
+| シナリオ | 条件 | 処理 |
+|---------|------|------|
+| インプレース変換 | Google アカウントが未登録 | ゲストユーザーレコードを Google ユーザーに変換。全データがそのまま保持される |
+| マージ | Google アカウントが既に存在 | ゲストの単語帳を既存 Google ユーザーに移行。ゲストユーザーは削除 |
+
+### エラーレスポンス（移行固有）
+
+| ステータス | 条件 | レスポンス |
+|-----------|------|-----------|
+| 401 Unauthorized | 無効な guest_token / ゲストユーザーが見つからない | `{ "error": "Invalid guest token" }` |
+| 422 Unprocessable Entity | guest_token のユーザーがゲストでない | `{ "error": "User is not a guest" }` |
+
 ## 認可（リソーススコーピング）
 
 全リソースエンドポイントは`current_user`を起点にスコーピング:

--- a/docs/guest_migration.md
+++ b/docs/guest_migration.md
@@ -1,0 +1,134 @@
+# ゲストユーザーデータの引き継ぎ（Guest Migration）
+
+## 概要
+
+ゲストユーザーが Google アカウントで本登録する際、ゲスト期間中に作成したデータを引き継ぐ機能。
+
+### 引き継ぎ対象データ
+
+- 単語帳（Wordbooks）
+- 単語（Words）— ステータス、次回復習日を含む
+- 意味（Meanings）
+- 例文（Examples）
+- 学習設定（Settings）— 復習間隔のカスタマイズ
+
+## API 仕様
+
+### エンドポイント
+
+`POST /api/v1/auth/google`（既存の Google 認証エンドポイントを拡張）
+
+### リクエスト
+
+```
+POST /api/v1/auth/google
+Authorization: Bearer <GOOGLE_ID_TOKEN>
+Content-Type: application/json
+
+{
+  "guest_token": "<GUEST_JWT>"
+}
+```
+
+- `Authorization` ヘッダー: Google ID トークン（必須、通常の Google 認証と同じ）
+- `guest_token`: ゲストユーザーの JWT トークン（オプション。指定時にデータ移行を実行）
+
+### レスポンス
+
+**成功時（200 OK）:**
+
+```json
+{
+  "user": {
+    "email": "user@example.com",
+    "name": "User Name",
+    "avatar_url": "https://example.com/avatar.jpg"
+  },
+  "token": "<NEW_JWT>"
+}
+```
+
+**エラー時:**
+
+| ステータス | 条件 | レスポンス |
+|-----------|------|-----------|
+| 400 Bad Request | Authorization ヘッダーなし | `{ "error": "Authorization header missing" }` |
+| 401 Unauthorized | Google ID トークンが無効 | `{ "error": "Invalid ID token" }` |
+| 401 Unauthorized | guest_token が無効 / ゲストユーザーが見つからない | `{ "error": "Invalid guest token" }` |
+| 422 Unprocessable Entity | guest_token のユーザーがゲストでない | `{ "error": "User is not a guest" }` |
+
+## 処理フロー
+
+### シナリオ A: インプレース変換（Google アカウント未登録の場合）
+
+最も一般的なケース。ゲストユーザーが初めて Google アカウントを登録する場合。
+
+```
+Guest User (id=1, provider="guest")
+  ↓ update!
+Google User (id=1, provider="google", provider_uid="sub値", email="...")
+```
+
+- User レコードの `provider`、`provider_uid`、`email`、`name`、`avatar_url` を更新
+- `guest_expires_at` を `nil` に設定
+- `user_id` は変わらないため、関連データ（Wordbooks 以下全て）はそのまま保持
+- User 数は変化しない
+
+### シナリオ B: マージ（Google アカウント既に存在する場合）
+
+別デバイスで先に Google 登録済みのユーザーがゲスト端末のデータを取り込むケース。
+
+```
+Guest User (id=1)              Google User (id=2)
+  ├── Wordbook A                 ├── Wordbook X
+  ├── Wordbook B                 └── Setting
+  └── Setting
+          ↓ マージ
+Google User (id=2)
+  ├── Wordbook X（既存）
+  ├── Wordbook A（移行）
+  ├── Wordbook B（移行）
+  └── Setting（既存を維持）
+```
+
+- ゲストの Wordbooks を Google ユーザーに `user_id` を付け替え（`update_all`）
+- Words / Meanings / Examples は `wordbook_id` 経由の FK で自動的に追随
+- Settings: Google ユーザーに設定がなければ移行、あれば既存を維持
+- ゲストユーザーを削除
+- User 数が 1 減少
+
+## 実装詳細
+
+### 主要ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `app/controllers/concerns/guest_migratable.rb` | 移行ロジック（Concern） |
+| `app/controllers/api/v1/auth_controller.rb` | エンドポイント（`google` アクション内で分岐） |
+
+### DB 制約との互換性
+
+インプレース変換時、以下の CHECK 制約はすべて満たされる：
+
+| 制約 | 変換後の状態 | 結果 |
+|------|------------|------|
+| `provider IN ('google', 'guest')` | `'google'` | OK |
+| `provider = 'guest' OR provider_uid IS NOT NULL` | `'google'` + `provider_uid` あり | OK |
+| `provider != 'guest' OR guest_expires_at IS NOT NULL` | `'google'` → 条件不問 | OK |
+| UNIQUE `(provider, provider_uid)` | 新しい組み合わせ → OK / 既存あり → マージへ | OK |
+| UNIQUE `email` | 新しい email → OK / 既存あり → マージへ | OK |
+
+DB マイグレーションは不要。
+
+### トランザクション
+
+全移行処理は `ActiveRecord::Base.transaction` で囲まれており、途中でエラーが発生した場合は全変更がロールバックされる。
+
+## エッジケース
+
+| ケース | 挙動 |
+|--------|------|
+| ゲストの有効期限切れ | JWT 自体が期限切れのため、`find_guest_user_from_token` で nil → 401 |
+| 同じゲストから2回リクエスト | 1回目で provider が `google` に変更済み → 2回目は `find_guest_user_from_token` で guest ユーザーが見つからず 401 |
+| Google ユーザーが guest_token を送信 | `find_guest_user_from_token` は `provider: "guest"` で検索するため nil → 401 |
+| guest_token なしで通常の Google 認証 | 既存動作がそのまま維持される（回帰なし） |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -42,8 +42,23 @@ paths:
         Verifies a Google ID token and finds or creates the user.
         Returns a JWT token for subsequent API requests.
         If the email is already registered with a different provider, returns 409 Conflict.
+
+        **Guest migration:** When `guest_token` is provided in the request body,
+        migrates the guest user's data (wordbooks, words, meanings, examples, settings)
+        to the Google account. If the Google account already exists, guest data is merged
+        into it; otherwise, the guest user record is converted in-place.
       security:
         - googleIdToken: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                guest_token:
+                  type: string
+                  description: JWT token of the guest user to migrate data from (optional)
       responses:
         "200":
           description: Authentication successful
@@ -80,6 +95,12 @@ paths:
                 $ref: "#/components/schemas/Error"
         "409":
           description: Email already registered with another provider
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "422":
+          description: Guest migration failed (e.g., guest_token user is not a guest)
           content:
             application/json:
               schema:

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -133,5 +133,169 @@ RSpec.describe "Api::V1::Auth", type: :request do
         expect(response.parsed_body["error"]).to include("already registered")
       end
     end
+
+    context "with guest_token (guest migration)" do
+      let(:guest_user) { create(:user, :guest) }
+      let(:guest_token) do
+        JWT.encode(
+          { sub: guest_user.id, exp: guest_user.guest_expires_at.to_i, iat: Time.current.to_i },
+          Rails.application.secret_key_base,
+          "HS256"
+        )
+      end
+
+      before do
+        allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return(google_payload)
+      end
+
+      context "when Google account does not exist (in-place conversion)" do
+        let!(:wordbook) { create(:wordbook, user: guest_user, title: "Guest Wordbook") }
+        let!(:word) { create(:word, wordbook: wordbook, spelling: "apple") }
+        let!(:meaning) { create(:meaning, word: word, content: "りんご") }
+        let!(:example) { create(:example, word: word, sentence: "I like apples.", translation: "りんごが好きです。") }
+        let!(:setting) { create(:setting, user: guest_user) }
+
+        it "converts guest user to Google user and returns ok" do
+          expect {
+            post "/api/v1/auth/google",
+                 params: { guest_token: guest_token },
+                 headers: { "Authorization" => "Bearer valid_token" }
+          }.not_to change(User, :count)
+
+          expect(response).to have_http_status(:ok)
+
+          body = response.parsed_body
+          expect(body["user"]["email"]).to eq("test@example.com")
+          expect(body["user"]["name"]).to eq("Test User")
+          expect(body["user"]["avatar_url"]).to eq("https://example.com/avatar.jpg")
+          expect(body["token"]).to be_present
+        end
+
+        it "updates guest user attributes to Google user" do
+          post "/api/v1/auth/google",
+               params: { guest_token: guest_token },
+               headers: { "Authorization" => "Bearer valid_token" }
+
+          guest_user.reload
+          expect(guest_user.provider).to eq("google")
+          expect(guest_user.provider_uid).to eq("google_uid_123")
+          expect(guest_user.email).to eq("test@example.com")
+          expect(guest_user.guest_expires_at).to be_nil
+        end
+
+        it "preserves all guest data (wordbooks, words, meanings, examples, settings)" do
+          post "/api/v1/auth/google",
+               params: { guest_token: guest_token },
+               headers: { "Authorization" => "Bearer valid_token" }
+
+          guest_user.reload
+          expect(guest_user.wordbooks.count).to eq(1)
+          expect(guest_user.wordbooks.first.title).to eq("Guest Wordbook")
+          expect(guest_user.wordbooks.first.words.count).to eq(1)
+          expect(guest_user.wordbooks.first.words.first.meanings.count).to eq(1)
+          expect(guest_user.wordbooks.first.words.first.examples.count).to eq(1)
+          expect(guest_user.setting).to be_present
+        end
+
+        it "returns a JWT token for the converted user" do
+          post "/api/v1/auth/google",
+               params: { guest_token: guest_token },
+               headers: { "Authorization" => "Bearer valid_token" }
+
+          token = response.parsed_body["token"]
+          decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: "HS256")
+          expect(decoded.first["sub"]).to eq(guest_user.id)
+        end
+      end
+
+      context "when Google account already exists (merge)" do
+        let!(:google_user) { create(:user, provider: "google", provider_uid: "google_uid_123", email: "test@example.com") }
+        let!(:guest_wordbook) { create(:wordbook, user: guest_user, title: "Guest Wordbook") }
+        let!(:guest_word) { create(:word, wordbook: guest_wordbook, spelling: "banana") }
+        let!(:guest_meaning) { create(:meaning, word: guest_word, content: "バナナ") }
+        let!(:guest_setting) { create(:setting, user: guest_user) }
+
+        it "merges guest data into existing Google user and deletes guest" do
+          expect {
+            post "/api/v1/auth/google",
+                 params: { guest_token: guest_token },
+                 headers: { "Authorization" => "Bearer valid_token" }
+          }.to change(User, :count).by(-1)
+
+          expect(response).to have_http_status(:ok)
+          expect { guest_user.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it "transfers wordbooks to the Google user" do
+          post "/api/v1/auth/google",
+               params: { guest_token: guest_token },
+               headers: { "Authorization" => "Bearer valid_token" }
+
+          expect(google_user.wordbooks.count).to eq(1)
+          expect(google_user.wordbooks.first.title).to eq("Guest Wordbook")
+          expect(google_user.wordbooks.first.words.first.meanings.count).to eq(1)
+        end
+
+        it "transfers setting when Google user has no setting" do
+          post "/api/v1/auth/google",
+               params: { guest_token: guest_token },
+               headers: { "Authorization" => "Bearer valid_token" }
+
+          expect(google_user.reload.setting).to be_present
+        end
+
+        it "keeps Google user setting when both have settings" do
+          google_setting = create(:setting, user: google_user, hard_interval: 2.days)
+
+          post "/api/v1/auth/google",
+               params: { guest_token: guest_token },
+               headers: { "Authorization" => "Bearer valid_token" }
+
+          google_user.reload
+          expect(google_user.setting.id).to eq(google_setting.id)
+        end
+
+        it "returns a JWT token for the Google user" do
+          post "/api/v1/auth/google",
+               params: { guest_token: guest_token },
+               headers: { "Authorization" => "Bearer valid_token" }
+
+          token = response.parsed_body["token"]
+          decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: "HS256")
+          expect(decoded.first["sub"]).to eq(google_user.id)
+        end
+      end
+
+      context "when guest_token is invalid" do
+        it "returns unauthorized" do
+          post "/api/v1/auth/google",
+               params: { guest_token: "invalid_token" },
+               headers: { "Authorization" => "Bearer valid_token" }
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(response.parsed_body["error"]).to eq("Invalid guest token")
+        end
+      end
+
+      context "when guest_token belongs to a Google user" do
+        let(:google_user) { create(:user, provider: "google", provider_uid: "other_uid") }
+        let(:non_guest_token) do
+          JWT.encode(
+            { sub: google_user.id, exp: 30.days.from_now.to_i, iat: Time.current.to_i },
+            Rails.application.secret_key_base,
+            "HS256"
+          )
+        end
+
+        it "returns unauthorized" do
+          post "/api/v1/auth/google",
+               params: { guest_token: non_guest_token },
+               headers: { "Authorization" => "Bearer valid_token" }
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(response.parsed_body["error"]).to eq("Invalid guest token")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Add `GuestMigratable` concern to handle guest-to-Google user migration with two scenarios: in-place conversion (no existing Google account) and merge (existing Google account)
- Extend `POST /api/v1/auth/google` with optional `guest_token` parameter to trigger migration while preserving backward compatibility
- Add comprehensive tests (10 new specs) covering both migration paths, data preservation, and error cases

## Details

When a guest user registers with Google, their data (wordbooks, words, meanings, examples, settings) is transferred to the Google account:

- **In-place conversion**: Guest user record is updated to become a Google user. All FK-linked data is automatically preserved.
- **Merge**: Guest's wordbooks are transferred to the existing Google user via `update_all`. Guest user is deleted after merge.

No database migration required — all existing CHECK and UNIQUE constraints are compatible.

## Test plan

- [x] `bundle exec rspec spec/requests/api/v1/auth_spec.rb` — 20 examples, 0 failures
- [x] `bundle exec rspec` — 126 examples, 0 failures (no regressions)
- [x] Manual test: create guest user → add wordbooks/words → call `/auth/google` with `guest_token` → verify data preserved
- [x] Manual test: create guest + separate Google user → merge via `guest_token` → verify data transferred
