### PR TITLE
Add commit strategy and message format guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,16 @@ Read these as needed based on the task.
 ## Workflow
 
 - Before starting implementation, enter plan mode to design the approach and align with the user.
+  - The plan must include a commit strategy: define how to group changes into logical commits and a draft commit message for each.
 - When beginning work, always pull the latest main branch and create a new branch with an appropriate name before making any changes.
+- During implementation, commit incrementally according to the plan. Create each commit as soon as the corresponding unit of work is complete, rather than batching all commits at the end.
+
+## Commit Messages
+
+- Write in English
+- Use the Conventional Commits format: `<type>: <description>`
+  - Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+- Do NOT include `Co-Authored-By` or any AI attribution
 
 ## Communication
 


### PR DESCRIPTION
## Summary

- Add commit strategy requirement to the planning workflow section
- Add incremental commit guideline during implementation
- Add commit message format section (Conventional Commits, no AI attribution)

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
