### PR TITLE
docs: extract commit rules into git-commit skill

### DIFF
--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: git-commit
+description: Git commit rules and conventions. Follow these when creating any git commit or planning commit strategy.
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git diff:*), AskUserQuestion
+---
+
+## Commit Message Rules
+
+- Write in English
+- Use the Conventional Commits format: `<type>: <description>`
+  - Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+- Keep the subject line under 72 characters
+- Do NOT include `Co-Authored-By` or any AI attribution
+
+## Commit Grouping Guidelines
+
+When multiple files are changed, group them into logical commits:
+
+- Group files that serve the same purpose
+- If there is only one file changed or all changes are clearly related, use a single commit
+
+## Commit Workflow
+
+When invoked directly, execute the following workflow.
+
+### Context
+
+- Current git status: !`git status`
+- Current git diff (uncommitted changes): !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+
+### Pre-check
+
+- If there are no uncommitted changes, inform the user and stop. Do NOT proceed.
+- Show the current branch name to the user and use AskUserQuestion to confirm:
+  - "Continue on this branch"
+  - "Stop" (user will switch branches manually)
+
+### 1. Analyze changes and propose commit groups
+
+Examine the diff and group changes into logical commits following the Commit Grouping Guidelines above.
+
+Present your proposed groupings to the user as a numbered list showing files and commit message per group. Then use AskUserQuestion to confirm:
+
+- "Proceed as proposed"
+- "Combine into one commit"
+- "Let me regroup" (user describes preferred grouping via Other)
+
+If the user selects "Let me regroup", revise the groupings based on their input and re-confirm.
+
+### 2. Commit
+
+For each commit group (in the confirmed order):
+
+- Stage only the files in that group with `git add`
+- Create a commit following the Commit Message Rules above

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,13 +26,7 @@ Read these as needed based on the task.
   - The plan must include a commit strategy: define how to group changes into logical commits and a draft commit message for each.
 - When beginning work, always pull the latest main branch and create a new branch with an appropriate name before making any changes.
 - During implementation, commit incrementally according to the plan. Create each commit as soon as the corresponding unit of work is complete, rather than batching all commits at the end.
-
-## Commit Messages
-
-- Write in English
-- Use the Conventional Commits format: `<type>: <description>`
-  - Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
-- Do NOT include `Co-Authored-By` or any AI attribution
+- When committing, follow the rules defined in `.claude/skills/git-commit/SKILL.md`.
 
 ## Communication
 


### PR DESCRIPTION
## Summary

- Add commit strategy and message format guidelines to CLAUDE.md workflow section
- Extract commit rules into a dedicated `git-commit` skill (`.claude/skills/git-commit/SKILL.md`) with commit message rules, grouping guidelines, and an interactive commit workflow
- Replace inline commit rules in CLAUDE.md with a reference to the new skill