### PR TITLE
refactor: nest routes to reflect model parent-child relationships

### DIFF
--- a/app/controllers/api/v1/examples_controller.rb
+++ b/app/controllers/api/v1/examples_controller.rb
@@ -1,10 +1,11 @@
 module Api
   module V1
     class ExamplesController < ApplicationController
+      before_action :set_word
       before_action :set_example, only: [ :show, :update, :destroy ]
 
       def index
-        examples = Example.joins(word: :wordbook).where(wordbooks: { user_id: current_user.id })
+        examples = @word.examples
         render json: examples
       end
 
@@ -13,8 +14,7 @@ module Api
       end
 
       def create
-        word = Word.joins(:wordbook).where(wordbooks: { user_id: current_user.id }).find(example_params[:word_id])
-        example = word.examples.new(example_params.except(:word_id))
+        example = @word.examples.new(example_params)
 
         if example.save
           render json: example, status: :created
@@ -24,7 +24,7 @@ module Api
       end
 
       def update
-        if @example.update(example_params.except(:word_id))
+        if @example.update(example_params)
           render json: @example
         else
           render json: { errors: @example.errors.full_messages }, status: :unprocessable_entity
@@ -38,12 +38,16 @@ module Api
 
       private
 
+      def set_word
+        @word = current_user.wordbooks.find(params[:wordbook_id]).words.find(params[:word_id])
+      end
+
       def set_example
-        @example = Example.joins(word: :wordbook).where(wordbooks: { user_id: current_user.id }).find(params[:id])
+        @example = @word.examples.find(params[:id])
       end
 
       def example_params
-        params.require(:example).permit(:word_id, :sentence, :translation, :display_order)
+        params.require(:example).permit(:sentence, :translation, :display_order)
       end
     end
   end

--- a/app/controllers/api/v1/meanings_controller.rb
+++ b/app/controllers/api/v1/meanings_controller.rb
@@ -1,10 +1,11 @@
 module Api
   module V1
     class MeaningsController < ApplicationController
+      before_action :set_word
       before_action :set_meaning, only: [ :show, :update, :destroy ]
 
       def index
-        meanings = Meaning.joins(word: :wordbook).where(wordbooks: { user_id: current_user.id })
+        meanings = @word.meanings
         render json: meanings
       end
 
@@ -13,8 +14,7 @@ module Api
       end
 
       def create
-        word = Word.joins(:wordbook).where(wordbooks: { user_id: current_user.id }).find(meaning_params[:word_id])
-        meaning = word.meanings.new(meaning_params.except(:word_id))
+        meaning = @word.meanings.new(meaning_params)
 
         if meaning.save
           render json: meaning, status: :created
@@ -24,7 +24,7 @@ module Api
       end
 
       def update
-        if @meaning.update(meaning_params.except(:word_id))
+        if @meaning.update(meaning_params)
           render json: @meaning
         else
           render json: { errors: @meaning.errors.full_messages }, status: :unprocessable_entity
@@ -38,12 +38,16 @@ module Api
 
       private
 
+      def set_word
+        @word = current_user.wordbooks.find(params[:wordbook_id]).words.find(params[:word_id])
+      end
+
       def set_meaning
-        @meaning = Meaning.joins(word: :wordbook).where(wordbooks: { user_id: current_user.id }).find(params[:id])
+        @meaning = @word.meanings.find(params[:id])
       end
 
       def meaning_params
-        params.require(:meaning).permit(:word_id, :content, :display_order)
+        params.require(:meaning).permit(:content, :display_order)
       end
     end
   end

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -3,11 +3,6 @@ module Api
     class SettingsController < ApplicationController
       before_action :set_setting, only: [ :show, :update, :destroy ]
 
-      def index
-        setting = current_user.setting
-        render json: setting ? [ setting_response(setting) ] : []
-      end
-
       def show
         render json: setting_response(@setting)
       end

--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -1,10 +1,11 @@
 module Api
   module V1
     class WordsController < ApplicationController
+      before_action :set_wordbook
       before_action :set_word, only: [ :show, :update, :destroy ]
 
       def index
-        words = Word.joins(:wordbook).where(wordbooks: { user_id: current_user.id })
+        words = @wordbook.words
         render json: words
       end
 
@@ -13,8 +14,7 @@ module Api
       end
 
       def create
-        wordbook = current_user.wordbooks.find(word_params[:wordbook_id])
-        word = wordbook.words.new(word_params.except(:wordbook_id))
+        word = @wordbook.words.new(word_params)
 
         if word.save
           render json: word, status: :created
@@ -24,7 +24,7 @@ module Api
       end
 
       def update
-        if @word.update(word_params.except(:wordbook_id))
+        if @word.update(word_params)
           render json: @word
         else
           render json: { errors: @word.errors.full_messages }, status: :unprocessable_entity
@@ -38,12 +38,16 @@ module Api
 
       private
 
+      def set_wordbook
+        @wordbook = current_user.wordbooks.find(params[:wordbook_id])
+      end
+
       def set_word
-        @word = Word.joins(:wordbook).where(wordbooks: { user_id: current_user.id }).find(params[:id])
+        @word = @wordbook.words.find(params[:id])
       end
 
       def word_params
-        params.require(:word).permit(:wordbook_id, :spelling, :status, :next_review_at)
+        params.require(:word).permit(:spelling, :status, :next_review_at)
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,9 @@ Rails.application.routes.draw do
       post "auth/google", to: "auth#google"
 
       # Resources
-      resources :wordbooks
-      resources :words
+      resources :wordbooks do
+        resources :words
+      end
       resources :meanings
       resources :examples
       resources :settings

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
           resources :examples
         end
       end
-      resources :settings
+      resource :setting, only: [ :show, :create, :update, :destroy ]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,10 +14,11 @@ Rails.application.routes.draw do
 
       # Resources
       resources :wordbooks do
-        resources :words
+        resources :words do
+          resources :meanings
+          resources :examples
+        end
       end
-      resources :meanings
-      resources :examples
       resources :settings
     end
   end

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -231,10 +231,12 @@ paths:
           $ref: "#/components/responses/NotFound"
 
   # ──────────────── Words ────────────────
-  /api/v1/words:
+  /api/v1/wordbooks/{wordbook_id}/words:
+    parameters:
+      - $ref: "#/components/parameters/WordbookId"
     get:
       tags: [Words]
-      summary: List current user's words
+      summary: List words in a wordbook
       security:
         - bearerAuth: []
       responses:
@@ -248,9 +250,11 @@ paths:
                   $ref: "#/components/schemas/Word"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     post:
       tags: [Words]
-      summary: Create a word
+      summary: Create a word in a wordbook
       security:
         - bearerAuth: []
       requestBody:
@@ -263,10 +267,8 @@ paths:
               properties:
                 word:
                   type: object
-                  required: [wordbook_id, spelling, status]
+                  required: [spelling, status]
                   properties:
-                    wordbook_id:
-                      type: integer
                     spelling:
                       type: string
                     status:
@@ -286,6 +288,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           description: Validation error
           content:
@@ -293,8 +297,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ValidationErrors"
 
-  /api/v1/words/{id}:
+  /api/v1/wordbooks/{wordbook_id}/words/{id}:
     parameters:
+      - $ref: "#/components/parameters/WordbookId"
       - $ref: "#/components/parameters/Id"
     get:
       tags: [Words]
@@ -369,10 +374,13 @@ paths:
           $ref: "#/components/responses/NotFound"
 
   # ──────────────── Meanings ────────────────
-  /api/v1/meanings:
+  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/meanings:
+    parameters:
+      - $ref: "#/components/parameters/WordbookId"
+      - $ref: "#/components/parameters/WordId"
     get:
       tags: [Meanings]
-      summary: List current user's meanings
+      summary: List meanings for a word
       security:
         - bearerAuth: []
       responses:
@@ -386,9 +394,11 @@ paths:
                   $ref: "#/components/schemas/Meaning"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     post:
       tags: [Meanings]
-      summary: Create a meaning
+      summary: Create a meaning for a word
       security:
         - bearerAuth: []
       requestBody:
@@ -401,10 +411,8 @@ paths:
               properties:
                 meaning:
                   type: object
-                  required: [word_id, content, display_order]
+                  required: [content, display_order]
                   properties:
-                    word_id:
-                      type: integer
                     content:
                       type: string
                     display_order:
@@ -421,6 +429,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           description: Validation error
           content:
@@ -428,8 +438,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/ValidationErrors"
 
-  /api/v1/meanings/{id}:
+  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/meanings/{id}:
     parameters:
+      - $ref: "#/components/parameters/WordbookId"
+      - $ref: "#/components/parameters/WordId"
       - $ref: "#/components/parameters/Id"
     get:
       tags: [Meanings]
@@ -501,10 +513,13 @@ paths:
           $ref: "#/components/responses/NotFound"
 
   # ──────────────── Examples ────────────────
-  /api/v1/examples:
+  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/examples:
+    parameters:
+      - $ref: "#/components/parameters/WordbookId"
+      - $ref: "#/components/parameters/WordId"
     get:
       tags: [Examples]
-      summary: List current user's examples
+      summary: List examples for a word
       security:
         - bearerAuth: []
       responses:
@@ -518,9 +533,11 @@ paths:
                   $ref: "#/components/schemas/Example"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     post:
       tags: [Examples]
-      summary: Create an example
+      summary: Create an example for a word
       security:
         - bearerAuth: []
       requestBody:
@@ -533,10 +550,8 @@ paths:
               properties:
                 example:
                   type: object
-                  required: [word_id, sentence, translation, display_order]
+                  required: [sentence, translation, display_order]
                   properties:
-                    word_id:
-                      type: integer
                     sentence:
                       type: string
                     translation:
@@ -555,6 +570,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           description: Validation error
           content:
@@ -562,8 +579,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/ValidationErrors"
 
-  /api/v1/examples/{id}:
+  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/examples/{id}:
     parameters:
+      - $ref: "#/components/parameters/WordbookId"
+      - $ref: "#/components/parameters/WordId"
       - $ref: "#/components/parameters/Id"
     get:
       tags: [Examples]
@@ -636,11 +655,11 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
-  # ──────────────── Settings ────────────────
-  /api/v1/settings:
+  # ──────────────── Setting (singular resource) ────────────────
+  /api/v1/setting:
     get:
       tags: [Settings]
-      summary: List current user's settings
+      summary: Get the current user's setting
       security:
         - bearerAuth: []
       responses:
@@ -649,11 +668,11 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Setting"
+                $ref: "#/components/schemas/Setting"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     post:
       tags: [Settings]
       summary: Create a setting
@@ -694,29 +713,9 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ValidationErrors"
-
-  /api/v1/settings/{id}:
-    parameters:
-      - $ref: "#/components/parameters/Id"
-    get:
-      tags: [Settings]
-      summary: Get a setting
-      security:
-        - bearerAuth: []
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Setting"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
     patch:
       tags: [Settings]
-      summary: Update a setting
+      summary: Update the setting
       security:
         - bearerAuth: []
       requestBody:
@@ -757,7 +756,7 @@ paths:
                 $ref: "#/components/schemas/ValidationErrors"
     delete:
       tags: [Settings]
-      summary: Delete a setting
+      summary: Delete the setting
       security:
         - bearerAuth: []
       responses:
@@ -783,6 +782,18 @@ components:
   parameters:
     Id:
       name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+    WordbookId:
+      name: wordbook_id
+      in: path
+      required: true
+      schema:
+        type: integer
+    WordId:
+      name: word_id
       in: path
       required: true
       schema:

--- a/spec/requests/api/v1/examples_spec.rb
+++ b/spec/requests/api/v1/examples_spec.rb
@@ -6,49 +6,59 @@ RSpec.describe "Api::V1::Examples", type: :request do
   let(:wordbook) { create(:wordbook, user: user) }
   let(:word) { create(:word, wordbook: wordbook) }
 
-  describe "GET /api/v1/examples" do
+  describe "GET /api/v1/wordbooks/:wordbook_id/words/:word_id/examples" do
     it "returns current user's examples" do
       create_list(:example, 2, word: word)
       create(:example) # another user's example
 
-      get "/api/v1/examples", headers: headers
+      get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples", headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body.size).to eq(2)
     end
 
     it "returns 401 without authentication" do
-      get "/api/v1/examples"
+      get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples"
 
       expect(response).to have_http_status(:unauthorized)
     end
+
+    it "returns not_found for another user's wordbook" do
+      other_wordbook = create(:wordbook)
+      other_word = create(:word, wordbook: other_wordbook)
+
+      get "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples", headers: headers
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
-  describe "GET /api/v1/examples/:id" do
+  describe "GET /api/v1/wordbooks/:wordbook_id/words/:word_id/examples/:id" do
     it "returns the example" do
       example = create(:example, word: word, sentence: "Good morning")
 
-      get "/api/v1/examples/#{example.id}", headers: headers
+      get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples/#{example.id}", headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["sentence"]).to eq("Good morning")
     end
 
     it "returns not_found for another user's example" do
-      other_example = create(:example)
+      other_wordbook = create(:wordbook)
+      other_word = create(:word, wordbook: other_wordbook)
+      other_example = create(:example, word: other_word)
 
-      get "/api/v1/examples/#{other_example.id}", headers: headers
+      get "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples/#{other_example.id}", headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "POST /api/v1/examples" do
+  describe "POST /api/v1/wordbooks/:wordbook_id/words/:word_id/examples" do
     context "with valid params" do
       it "creates an example" do
         params = {
           example: {
-            word_id: word.id,
             sentence: "See you later",
             translation: "またね",
             display_order: 1
@@ -56,7 +66,7 @@ RSpec.describe "Api::V1::Examples", type: :request do
         }
 
         expect {
-          post "/api/v1/examples", params: params, headers: headers
+          post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples", params: params, headers: headers
         }.to change(Example, :count).by(1)
 
         expect(response).to have_http_status(:created)
@@ -65,55 +75,60 @@ RSpec.describe "Api::V1::Examples", type: :request do
 
     context "with invalid params" do
       it "returns unprocessable_entity" do
-        post "/api/v1/examples", params: { example: { word_id: word.id, sentence: "", translation: "翻訳", display_order: 1 } }, headers: headers
+        post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples", params: { example: { sentence: "", translation: "翻訳", display_order: 1 } }, headers: headers
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 
     it "returns not_found when word belongs to another user" do
-      other_word = create(:word)
+      other_wordbook = create(:wordbook)
+      other_word = create(:word, wordbook: other_wordbook)
 
-      post "/api/v1/examples", params: { example: { word_id: other_word.id, sentence: "test", translation: "test", display_order: 1 } }, headers: headers
+      post "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples", params: { example: { sentence: "test", translation: "test", display_order: 1 } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "PATCH /api/v1/examples/:id" do
+  describe "PATCH /api/v1/wordbooks/:wordbook_id/words/:word_id/examples/:id" do
     let(:example_record) { create(:example, word: word) }
 
     it "updates the example" do
-      patch "/api/v1/examples/#{example_record.id}", params: { example: { sentence: "Updated sentence" } }, headers: headers
+      patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples/#{example_record.id}", params: { example: { sentence: "Updated sentence" } }, headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["sentence"]).to eq("Updated sentence")
     end
 
     it "returns not_found for another user's example" do
-      other_example = create(:example)
+      other_wordbook = create(:wordbook)
+      other_word = create(:word, wordbook: other_wordbook)
+      other_example = create(:example, word: other_word)
 
-      patch "/api/v1/examples/#{other_example.id}", params: { example: { sentence: "hacked" } }, headers: headers
+      patch "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples/#{other_example.id}", params: { example: { sentence: "hacked" } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "DELETE /api/v1/examples/:id" do
+  describe "DELETE /api/v1/wordbooks/:wordbook_id/words/:word_id/examples/:id" do
     it "deletes the example" do
       example_record = create(:example, word: word)
 
       expect {
-        delete "/api/v1/examples/#{example_record.id}", headers: headers
+        delete "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples/#{example_record.id}", headers: headers
       }.to change(Example, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end
 
     it "returns not_found for another user's example" do
-      other_example = create(:example)
+      other_wordbook = create(:wordbook)
+      other_word = create(:word, wordbook: other_wordbook)
+      other_example = create(:example, word: other_word)
 
-      delete "/api/v1/examples/#{other_example.id}", headers: headers
+      delete "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples/#{other_example.id}", headers: headers
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/requests/api/v1/meanings_spec.rb
+++ b/spec/requests/api/v1/meanings_spec.rb
@@ -6,48 +6,59 @@ RSpec.describe "Api::V1::Meanings", type: :request do
   let(:wordbook) { create(:wordbook, user: user) }
   let(:word) { create(:word, wordbook: wordbook) }
 
-  describe "GET /api/v1/meanings" do
+  describe "GET /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings" do
     it "returns current user's meanings" do
       create_list(:meaning, 2, word: word)
       create(:meaning) # another user's meaning
 
-      get "/api/v1/meanings", headers: headers
+      get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings", headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body.size).to eq(2)
     end
 
     it "returns 401 without authentication" do
-      get "/api/v1/meanings"
+      get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings"
 
       expect(response).to have_http_status(:unauthorized)
     end
+
+    it "returns not_found for another user's wordbook" do
+      other_wordbook = create(:wordbook)
+      other_word = create(:word, wordbook: other_wordbook)
+
+      get "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings", headers: headers
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
-  describe "GET /api/v1/meanings/:id" do
+  describe "GET /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:id" do
     it "returns the meaning" do
       meaning = create(:meaning, word: word, content: "挨拶")
 
-      get "/api/v1/meanings/#{meaning.id}", headers: headers
+      get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}", headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["content"]).to eq("挨拶")
     end
 
     it "returns not_found for another user's meaning" do
-      other_meaning = create(:meaning)
+      other_wordbook = create(:wordbook)
+      other_word = create(:word, wordbook: other_wordbook)
+      other_meaning = create(:meaning, word: other_word)
 
-      get "/api/v1/meanings/#{other_meaning.id}", headers: headers
+      get "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings/#{other_meaning.id}", headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "POST /api/v1/meanings" do
+  describe "POST /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings" do
     context "with valid params" do
       it "creates a meaning" do
         expect {
-          post "/api/v1/meanings", params: { meaning: { word_id: word.id, content: "意味", display_order: 1 } }, headers: headers
+          post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings", params: { meaning: { content: "意味", display_order: 1 } }, headers: headers
         }.to change(Meaning, :count).by(1)
 
         expect(response).to have_http_status(:created)
@@ -56,55 +67,60 @@ RSpec.describe "Api::V1::Meanings", type: :request do
 
     context "with invalid params" do
       it "returns unprocessable_entity" do
-        post "/api/v1/meanings", params: { meaning: { word_id: word.id, content: "", display_order: 1 } }, headers: headers
+        post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings", params: { meaning: { content: "", display_order: 1 } }, headers: headers
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 
     it "returns not_found when word belongs to another user" do
-      other_word = create(:word)
+      other_wordbook = create(:wordbook)
+      other_word = create(:word, wordbook: other_wordbook)
 
-      post "/api/v1/meanings", params: { meaning: { word_id: other_word.id, content: "test", display_order: 1 } }, headers: headers
+      post "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings", params: { meaning: { content: "test", display_order: 1 } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "PATCH /api/v1/meanings/:id" do
+  describe "PATCH /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:id" do
     let(:meaning) { create(:meaning, word: word) }
 
     it "updates the meaning" do
-      patch "/api/v1/meanings/#{meaning.id}", params: { meaning: { content: "更新された意味" } }, headers: headers
+      patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}", params: { meaning: { content: "更新された意味" } }, headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["content"]).to eq("更新された意味")
     end
 
     it "returns not_found for another user's meaning" do
-      other_meaning = create(:meaning)
+      other_wordbook = create(:wordbook)
+      other_word = create(:word, wordbook: other_wordbook)
+      other_meaning = create(:meaning, word: other_word)
 
-      patch "/api/v1/meanings/#{other_meaning.id}", params: { meaning: { content: "hacked" } }, headers: headers
+      patch "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings/#{other_meaning.id}", params: { meaning: { content: "hacked" } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "DELETE /api/v1/meanings/:id" do
+  describe "DELETE /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:id" do
     it "deletes the meaning" do
       meaning = create(:meaning, word: word)
 
       expect {
-        delete "/api/v1/meanings/#{meaning.id}", headers: headers
+        delete "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}", headers: headers
       }.to change(Meaning, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end
 
     it "returns not_found for another user's meaning" do
-      other_meaning = create(:meaning)
+      other_wordbook = create(:wordbook)
+      other_word = create(:word, wordbook: other_wordbook)
+      other_meaning = create(:meaning, word: other_word)
 
-      delete "/api/v1/meanings/#{other_meaning.id}", headers: headers
+      delete "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings/#{other_meaning.id}", headers: headers
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -4,40 +4,11 @@ RSpec.describe "Api::V1::Settings", type: :request do
   let(:user) { create(:user) }
   let(:headers) { auth_headers_for(user) }
 
-  describe "GET /api/v1/settings" do
-    it "returns current user's settings" do
-      create(:setting, user: user)
-
-      get "/api/v1/settings", headers: headers
-
-      expect(response).to have_http_status(:ok)
-      body = response.parsed_body
-      expect(body.size).to eq(1)
-      expect(body.first["hard_interval"]).to include("days", "hours", "minutes")
-    end
-
-    it "does not return other users' settings" do
-      create(:setting, user: user)
-      create(:setting) # another user's setting
-
-      get "/api/v1/settings", headers: headers
-
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body.size).to eq(1)
-    end
-
-    it "returns 401 without authentication" do
-      get "/api/v1/settings"
-
-      expect(response).to have_http_status(:unauthorized)
-    end
-  end
-
-  describe "GET /api/v1/settings/:id" do
+  describe "GET /api/v1/setting" do
     it "returns the current user's setting" do
       setting = create(:setting, user: user)
 
-      get "/api/v1/settings/#{setting.id}", headers: headers
+      get "/api/v1/setting", headers: headers
 
       expect(response).to have_http_status(:ok)
       body = response.parsed_body
@@ -47,13 +18,19 @@ RSpec.describe "Api::V1::Settings", type: :request do
     end
 
     it "returns not_found when user has no setting" do
-      get "/api/v1/settings/999999", headers: headers
+      get "/api/v1/setting", headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
+
+    it "returns 401 without authentication" do
+      get "/api/v1/setting"
+
+      expect(response).to have_http_status(:unauthorized)
+    end
   end
 
-  describe "POST /api/v1/settings" do
+  describe "POST /api/v1/setting" do
     context "with valid params" do
       it "creates a setting for the current user" do
         params = {
@@ -65,7 +42,7 @@ RSpec.describe "Api::V1::Settings", type: :request do
         }
 
         expect {
-          post "/api/v1/settings", params: params, headers: headers
+          post "/api/v1/setting", params: params, headers: headers
         }.to change(Setting, :count).by(1)
 
         expect(response).to have_http_status(:created)
@@ -81,18 +58,18 @@ RSpec.describe "Api::V1::Settings", type: :request do
           }
         }
 
-        post "/api/v1/settings", params: params, headers: headers
+        post "/api/v1/setting", params: params, headers: headers
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end
 
-  describe "PATCH /api/v1/settings/:id" do
+  describe "PATCH /api/v1/setting" do
     let!(:setting) { create(:setting, user: user) }
 
     it "updates the setting" do
-      patch "/api/v1/settings/#{setting.id}", params: {
+      patch "/api/v1/setting", params: {
         setting: {
           hard_interval: { days: 2, hours: 0, minutes: 0 }
         }
@@ -103,12 +80,12 @@ RSpec.describe "Api::V1::Settings", type: :request do
     end
   end
 
-  describe "DELETE /api/v1/settings/:id" do
+  describe "DELETE /api/v1/setting" do
     it "deletes the setting" do
       setting = create(:setting, user: user)
 
       expect {
-        delete "/api/v1/settings/#{setting.id}", headers: headers
+        delete "/api/v1/setting", headers: headers
       }.to change(Setting, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -5,48 +5,57 @@ RSpec.describe "Api::V1::Words", type: :request do
   let(:headers) { auth_headers_for(user) }
   let(:wordbook) { create(:wordbook, user: user) }
 
-  describe "GET /api/v1/words" do
+  describe "GET /api/v1/wordbooks/:wordbook_id/words" do
     it "returns current user's words" do
       create_list(:word, 3, wordbook: wordbook)
       create(:word) # another user's word
 
-      get "/api/v1/words", headers: headers
+      get "/api/v1/wordbooks/#{wordbook.id}/words", headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body.size).to eq(3)
     end
 
     it "returns 401 without authentication" do
-      get "/api/v1/words"
+      get "/api/v1/wordbooks/#{wordbook.id}/words"
 
       expect(response).to have_http_status(:unauthorized)
     end
+
+    it "returns not_found for another user's wordbook" do
+      other_wordbook = create(:wordbook)
+
+      get "/api/v1/wordbooks/#{other_wordbook.id}/words", headers: headers
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
-  describe "GET /api/v1/words/:id" do
+  describe "GET /api/v1/wordbooks/:wordbook_id/words/:id" do
     it "returns the word" do
       word = create(:word, wordbook: wordbook, spelling: "apple")
 
-      get "/api/v1/words/#{word.id}", headers: headers
+      get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}", headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["spelling"]).to eq("apple")
     end
 
     it "returns not_found for another user's word" do
-      other_word = create(:word)
+      other_wordbook = create(:wordbook)
+      other_word = create(:word, wordbook: other_wordbook)
 
-      get "/api/v1/words/#{other_word.id}", headers: headers
+      get "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}", headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "POST /api/v1/words" do
+  describe "POST /api/v1/wordbooks/:wordbook_id/words" do
     context "with valid params" do
       it "creates a word" do
         expect {
-          post "/api/v1/words", params: { word: { wordbook_id: wordbook.id, spelling: "banana", status: "not_studied" } }, headers: headers
+          post "/api/v1/wordbooks/#{wordbook.id}/words", params: { word: { spelling: "banana", status: "not_studied" } }, headers: headers
         }.to change(Word, :count).by(1)
 
         expect(response).to have_http_status(:created)
@@ -56,7 +65,7 @@ RSpec.describe "Api::V1::Words", type: :request do
 
     context "with invalid params" do
       it "returns unprocessable_entity" do
-        post "/api/v1/words", params: { word: { wordbook_id: wordbook.id, spelling: "", status: "not_studied" } }, headers: headers
+        post "/api/v1/wordbooks/#{wordbook.id}/words", params: { word: { spelling: "", status: "not_studied" } }, headers: headers
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"]).to include("Spelling can't be blank")
@@ -66,46 +75,48 @@ RSpec.describe "Api::V1::Words", type: :request do
     it "returns not_found when wordbook belongs to another user" do
       other_wordbook = create(:wordbook)
 
-      post "/api/v1/words", params: { word: { wordbook_id: other_wordbook.id, spelling: "test", status: "not_studied" } }, headers: headers
+      post "/api/v1/wordbooks/#{other_wordbook.id}/words", params: { word: { spelling: "test", status: "not_studied" } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "PATCH /api/v1/words/:id" do
+  describe "PATCH /api/v1/wordbooks/:wordbook_id/words/:id" do
     let(:word) { create(:word, wordbook: wordbook) }
 
     it "updates the word" do
-      patch "/api/v1/words/#{word.id}", params: { word: { spelling: "cherry" } }, headers: headers
+      patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}", params: { word: { spelling: "cherry" } }, headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["spelling"]).to eq("cherry")
     end
 
     it "returns not_found for another user's word" do
-      other_word = create(:word)
+      other_wordbook = create(:wordbook)
+      other_word = create(:word, wordbook: other_wordbook)
 
-      patch "/api/v1/words/#{other_word.id}", params: { word: { spelling: "hacked" } }, headers: headers
+      patch "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}", params: { word: { spelling: "hacked" } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "DELETE /api/v1/words/:id" do
+  describe "DELETE /api/v1/wordbooks/:wordbook_id/words/:id" do
     it "deletes the word" do
       word = create(:word, wordbook: wordbook)
 
       expect {
-        delete "/api/v1/words/#{word.id}", headers: headers
+        delete "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}", headers: headers
       }.to change(Word, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end
 
     it "returns not_found for another user's word" do
-      other_word = create(:word)
+      other_wordbook = create(:wordbook)
+      other_word = create(:word, wordbook: other_wordbook)
 
-      delete "/api/v1/words/#{other_word.id}", headers: headers
+      delete "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}", headers: headers
 
       expect(response).to have_http_status(:not_found)
     end


### PR DESCRIPTION
## Summary
- Nest words routes under wordbooks, meanings/examples under words to reflect model hierarchy
- Convert settings from plural `resources` to singular `resource :setting` (one per user, no ID needed)
- Update OpenAPI spec to match the new nested route structure