### PR TITLE
feat: optimize N+1 API fetch patterns

### DIFF
--- a/app/controllers/api/v1/test/words_controller.rb
+++ b/app/controllers/api/v1/test/words_controller.rb
@@ -1,0 +1,22 @@
+module Api
+  module V1
+    module Test
+      class WordsController < ApplicationController
+        def index
+          wordbook = current_user.wordbooks.find(params[:wordbook_id])
+          words = wordbook.words.reviewable.includes(:meanings, :examples)
+
+          render json: {
+            wordbook: wordbook.as_json(only: [ :id, :title ]),
+            words: words.map { |word|
+              word.as_json.merge(
+                meanings: word.meanings.sort_by(&:display_order).as_json,
+                examples: word.examples.sort_by(&:display_order).as_json
+              )
+            }
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -12,7 +12,11 @@ module Api
       end
 
       def show
-        render json: @word
+        includes = parse_includes
+        if includes.any?
+          @word = @wordbook.words.includes(*includes.map(&:to_sym)).find(params[:id])
+        end
+        render json: word_json(@word, includes: includes)
       end
 
       def create
@@ -46,6 +50,21 @@ module Api
 
       def set_word
         @word = @wordbook.words.find(params[:id])
+      end
+
+      ALLOWED_INCLUDES = %w[meanings examples].freeze
+
+      def parse_includes
+        return [] if params[:include].blank?
+        params[:include].split(",").map(&:strip).select { |i| ALLOWED_INCLUDES.include?(i) }
+      end
+
+      def word_json(word, includes: [])
+        json = word.as_json
+        includes.each do |assoc|
+          json[assoc] = word.public_send(assoc).sort_by(&:display_order).as_json
+        end
+        json
       end
 
       def word_params

--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -5,8 +5,10 @@ module Api
       before_action :set_word, only: [ :show, :update, :destroy ]
 
       def index
-        words = @wordbook.words
-        render json: words
+        words = @wordbook.words.includes(:first_meaning)
+        render json: words.map { |word|
+          word.as_json.merge(first_meaning: word.first_meaning&.as_json)
+        }
       end
 
       def show

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -2,9 +2,12 @@ class Word < ApplicationRecord
   belongs_to :wordbook
   has_many :meanings, dependent: :destroy
   has_many :examples, dependent: :destroy
+  has_one :first_meaning, -> { order(:display_order) }, class_name: "Meaning"
 
   validates :spelling, presence: true
   validates :status, presence: true
 
   enum :status, { not_studied: "not_studied", hard: "hard", uncertain: "uncertain", easy: "easy" }
+
+  scope :reviewable, -> { where("next_review_at IS NULL OR next_review_at <= ?", Time.current) }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
 
       # Resources
       resources :wordbooks do
+        namespace :test do
+          resources :words, only: [ :index ]
+        end
         resources :words do
           resources :meanings
           resources :examples

--- a/docs/api-n-plus-1-optimization.md
+++ b/docs/api-n-plus-1-optimization.md
@@ -1,0 +1,244 @@
+# API N+1 Fetch 最適化提案
+
+フロントエンドで発生している N+1 API fetch パターンを調査し、Rails API 側の改善案をまとめる。
+
+## 概要
+
+| # | パターン | 発生箇所 | 現在のリクエスト数 | 最悪ケース | API 改善案 |
+|---|---------|---------|------------------|-----------|-----------|
+| 1 | 単語一覧 + 意味 | `components/word/word-list.tsx` | 1 + N | 101回 (100語) | words に first_meaning を含める |
+| 2 | 単語詳細 + 意味 + 例文 | `words/[wordId]/` 詳細・編集 | 3 | 3回 | word に meanings, examples を含める |
+| 3 | テストページ | `wordbooks/[wordbookId]/test/page.tsx` | 2 + 2N | 42回 (20語) | テスト専用エンドポイント or include パラメータ |
+
+---
+
+## パターン 1: 単語一覧での意味取得 (高優先度) ✅ 実装済み
+
+### 現状
+
+`src/components/word/word-list.tsx`
+
+```typescript
+// 1回目: 全単語を取得
+const allWords = await listWords(wordbookId);
+
+// N回: 各単語の意味を個別に取得
+const meaningEntries = await Promise.all(
+  allWords.map(async (word) => {
+    const meanings = await listMeanings(wordbookId, word.id);
+    const first = meanings.sort(/* display_order */)[0];
+    return [word.id, first] as const;
+  }),
+);
+```
+
+一覧画面では各単語の最初の意味（`display_order` 順）だけが必要だが、単語ごとに `GET /wordbooks/:wordbookId/words/:wordId/meanings` を呼んでいる。
+
+### リクエスト数
+
+- **現在:** 1 + N（N = 単語数）
+- 100語の単語帳 → **101リクエスト**
+
+### API 改善案
+
+`GET /wordbooks/:wordbookId/words` のレスポンスに `first_meaning` を含める。
+
+```jsonc
+// GET /wordbooks/:wordbookId/words
+{
+  "words": [
+    {
+      "id": 1,
+      "spelling": "apple",
+      "status": "not_studied",
+      "next_review_at": null,
+      // 追加: display_order が最小の meaning を1件だけ含める
+      "first_meaning": {
+        "id": 10,
+        "content": "りんご",
+        "display_order": 1
+      }
+    }
+  ]
+}
+```
+
+`first_meaning` は Rails 側で `has_one :first_meaning, -> { order(:display_order) }, class_name: 'Meaning'` のようなアソシエーションで実装し、`includes(:first_meaning)` で eager load する。
+
+**効果:** 101リクエスト → **1リクエスト**
+
+---
+
+## パターン 2: 単語詳細ページでの関連データ取得 (中優先度) ✅ 実装済み
+
+### 現状
+
+`src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/word-detail-content.tsx`
+
+```typescript
+// 1回目: 単語を取得
+word = await getWord(wordbookId, wordId);
+
+// 2回目 + 3回目: 意味と例文を並行取得
+const [meanings, examples] = await Promise.all([
+  listMeanings(wordbookId, wordId),
+  listExamples(wordbookId, wordId),
+]);
+```
+
+同じパターンが編集ページ (`words/[wordId]/edit/page.tsx`) にもある。
+
+### リクエスト数
+
+- **現在:** 3回（毎回固定）
+- 詳細ページと編集ページそれぞれで発生
+
+### API 改善案
+
+`GET /wordbooks/:wordbookId/words/:wordId` に `include` パラメータを追加。
+
+```
+GET /wordbooks/:wordbookId/words/:wordId?include=meanings,examples
+```
+
+```jsonc
+// レスポンス
+{
+  "word": {
+    "id": 1,
+    "spelling": "apple",
+    "status": "not_studied",
+    "next_review_at": null,
+    // 追加
+    "meanings": [
+      { "id": 10, "content": "りんご", "display_order": 1 },
+      { "id": 11, "content": "果物の一種", "display_order": 2 }
+    ],
+    // 追加
+    "examples": [
+      {
+        "id": 20,
+        "sentence": "An apple a day keeps the doctor away.",
+        "translation": "1日1個のりんごで医者いらず。",
+        "display_order": 1
+      }
+    ]
+  }
+}
+```
+
+Rails 側では `includes(:meanings, :examples)` で eager load。`include` パラメータがない場合は既存のレスポンスを維持し、後方互換性を保つ。
+
+**効果:** 3リクエスト → **1リクエスト**
+
+---
+
+## パターン 3: テストページでの単語 + 意味 + 例文取得 (最高優先度) ✅ 実装済み
+
+### 現状
+
+`src/app/(authenticated)/wordbooks/[wordbookId]/test/page.tsx`
+
+```typescript
+// 1回目: 単語帳を取得
+let wordbook = await getWordbook(wordbookId);
+
+// 2回目: 全単語を取得
+const allWords = await listWords(wordbookId);
+
+// フィルタリング: next_review_at が null or 過去の単語を抽出
+const reviewWords = allWords.filter(/* ... */);
+
+// 2N回: 各レビュー対象単語の意味と例文を個別に取得
+const wordsWithRelations = await Promise.all(
+  reviewWords.map(async (word) => {
+    const [meanings, examples] = await Promise.all([
+      listMeanings(wordbookId, word.id),   // N回
+      listExamples(wordbookId, word.id),   // N回
+    ]);
+    return { word, meanings, examples };
+  }),
+);
+```
+
+### リクエスト数
+
+- **現在:** 2 + 2N（N = レビュー対象の単語数）
+- 20語がレビュー対象 → **42リクエスト**
+
+### API 改善案
+
+#### 案 A: テスト専用エンドポイントの新設（推奨）
+
+```
+GET /wordbooks/:wordbookId/test/words
+```
+
+サーバー側でレビュー対象の単語をフィルタリングし、意味と例文を含めて返す。
+
+```jsonc
+// レスポンス
+{
+  "wordbook": {
+    "id": 1,
+    "title": "English Vocabulary"
+  },
+  "words": [
+    {
+      "id": 1,
+      "spelling": "apple",
+      "status": "not_studied",
+      "next_review_at": null,
+      "meanings": [
+        { "id": 10, "content": "りんご", "display_order": 1 }
+      ],
+      "examples": [
+        {
+          "id": 20,
+          "sentence": "An apple a day keeps the doctor away.",
+          "translation": "1日1個のりんごで医者いらず。",
+          "display_order": 1
+        }
+      ]
+    }
+  ]
+}
+```
+
+レビュー対象のフィルタ条件（`next_review_at IS NULL OR next_review_at <= NOW()`）をサーバー側に移すことで、不要な単語の転送も省ける。
+
+#### 案 B: 既存エンドポイントに include パラメータ追加
+
+```
+GET /wordbooks/:wordbookId/words?include=meanings,examples
+```
+
+フィルタリングはフロントエンド側で行うが、N+1 は解消される。パターン 1 の改善と組み合わせて `include` パラメータを汎用的に設計できる。
+
+**推奨:** 案 A。テストページはパフォーマンスが特に重要であり、サーバー側フィルタリングにより転送量も削減できる。
+
+**効果:** 42リクエスト → **1リクエスト**
+
+---
+
+## 実装の優先順位
+
+1. **パターン 3（テストページ）** — リクエスト数が最も多く、ユーザーが頻繁に使う機能
+2. **パターン 1（単語一覧）** — 単語数に比例してリクエストが増加
+3. **パターン 2（単語詳細）** — 固定3リクエストで影響は限定的だが、改善は容易
+
+## N+1 が発生していない箇所
+
+以下の箇所は問題なし:
+
+- **ダッシュボード** — `listWordbooks()` の1回のみ
+- **単語帳編集** — `getWordbook()` の1回のみ
+- **単語作成** — 単語帳の存在確認のみ
+- **設定ページ** — `getSetting()` の1回のみ
+
+## Rails 側の実装メモ
+
+- `includes` / `eager_load` を使い、SQL レベルで N+1 を解消する
+- `include` クエリパラメータは後方互換性のためオプショナルにする
+- テスト専用エンドポイント（案 A）では `Word.reviewable` スコープを定義し、フィルタ条件をモデルに集約する
+- シリアライザ（ActiveModelSerializers / Blueprinter 等）でネスト構造を定義する

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -237,6 +237,7 @@ paths:
     get:
       tags: [Words]
       summary: List words in a wordbook
+      description: Returns all words with their first meaning (by display_order) included.
       security:
         - bearerAuth: []
       responses:
@@ -247,7 +248,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Word"
+                  $ref: "#/components/schemas/WordWithFirstMeaning"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -304,15 +305,26 @@ paths:
     get:
       tags: [Words]
       summary: Get a word
+      description: |
+        Returns a word. Use the `include` query parameter to embed related resources.
+        Without `include`, only the word fields are returned (backward compatible).
       security:
         - bearerAuth: []
+      parameters:
+        - name: include
+          in: query
+          required: false
+          description: Comma-separated list of relations to include. Allowed values: meanings, examples.
+          schema:
+            type: string
+            example: meanings,examples
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Word"
+                $ref: "#/components/schemas/WordWithRelations"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -368,6 +380,30 @@ paths:
       responses:
         "204":
           description: No Content
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ──────────────── Test Words ────────────────
+  /api/v1/wordbooks/{wordbook_id}/test/words:
+    parameters:
+      - $ref: "#/components/parameters/WordbookId"
+    get:
+      tags: [Test]
+      summary: List reviewable words for test
+      description: |
+        Returns words that are due for review (next_review_at is null or in the past),
+        with their meanings and examples eager-loaded. Designed for the test/quiz page.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestWordsResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -902,6 +938,59 @@ components:
         updated_at:
           type: string
           format: date-time
+
+    WordWithFirstMeaning:
+      allOf:
+        - $ref: "#/components/schemas/Word"
+        - type: object
+          properties:
+            first_meaning:
+              nullable: true
+              description: The meaning with the lowest display_order, or null if no meanings exist
+              allOf:
+                - $ref: "#/components/schemas/Meaning"
+
+    WordWithRelations:
+      allOf:
+        - $ref: "#/components/schemas/Word"
+        - type: object
+          properties:
+            meanings:
+              type: array
+              description: Present only when include=meanings is specified
+              items:
+                $ref: "#/components/schemas/Meaning"
+            examples:
+              type: array
+              description: Present only when include=examples is specified
+              items:
+                $ref: "#/components/schemas/Example"
+
+    TestWordsResponse:
+      type: object
+      properties:
+        wordbook:
+          type: object
+          properties:
+            id:
+              type: integer
+            title:
+              type: string
+        words:
+          type: array
+          items:
+            allOf:
+              - $ref: "#/components/schemas/Word"
+              - type: object
+                properties:
+                  meanings:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Meaning"
+                  examples:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Example"
 
     WordStatus:
       type: string

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Word, type: :model do
     it { is_expected.to belong_to(:wordbook) }
     it { is_expected.to have_many(:meanings).dependent(:destroy) }
     it { is_expected.to have_many(:examples).dependent(:destroy) }
+    it { is_expected.to have_one(:first_meaning).class_name("Meaning") }
   end
 
   describe "validations" do
@@ -17,6 +18,27 @@ RSpec.describe Word, type: :model do
       is_expected.to define_enum_for(:status)
         .with_values(not_studied: "not_studied", hard: "hard", uncertain: "uncertain", easy: "easy")
         .backed_by_column_of_type(:string)
+    end
+  end
+
+  describe "scopes" do
+    describe ".reviewable" do
+      let(:wordbook) { create(:wordbook) }
+
+      it "includes words with next_review_at as nil" do
+        word = create(:word, wordbook: wordbook, next_review_at: nil)
+        expect(Word.reviewable).to include(word)
+      end
+
+      it "includes words with next_review_at in the past" do
+        word = create(:word, wordbook: wordbook, next_review_at: 1.day.ago)
+        expect(Word.reviewable).to include(word)
+      end
+
+      it "excludes words with next_review_at in the future" do
+        word = create(:word, wordbook: wordbook, next_review_at: 1.day.from_now)
+        expect(Word.reviewable).not_to include(word)
+      end
     end
   end
 

--- a/spec/requests/api/v1/test/words_spec.rb
+++ b/spec/requests/api/v1/test/words_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Test::Words", type: :request do
+  let(:user) { create(:user) }
+  let(:headers) { auth_headers_for(user) }
+  let(:wordbook) { create(:wordbook, user: user) }
+
+  describe "GET /api/v1/wordbooks/:wordbook_id/test/words" do
+    it "returns reviewable words with meanings and examples" do
+      word = create(:word, wordbook: wordbook, next_review_at: nil)
+      meaning = create(:meaning, word: word, content: "りんご", display_order: 1)
+      example = create(:example, word: word, sentence: "I like apples.", display_order: 1)
+
+      get "/api/v1/wordbooks/#{wordbook.id}/test/words", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["wordbook"]["id"]).to eq(wordbook.id)
+      expect(body["wordbook"]["title"]).to eq(wordbook.title)
+      expect(body["words"].size).to eq(1)
+
+      returned_word = body["words"].first
+      expect(returned_word["spelling"]).to eq(word.spelling)
+      expect(returned_word["meanings"].size).to eq(1)
+      expect(returned_word["meanings"].first["content"]).to eq("りんご")
+      expect(returned_word["examples"].size).to eq(1)
+      expect(returned_word["examples"].first["sentence"]).to eq("I like apples.")
+    end
+
+    it "includes words with next_review_at in the past" do
+      word = create(:word, wordbook: wordbook, next_review_at: 1.day.ago)
+
+      get "/api/v1/wordbooks/#{wordbook.id}/test/words", headers: headers
+
+      expect(response.parsed_body["words"].size).to eq(1)
+    end
+
+    it "excludes words with next_review_at in the future" do
+      create(:word, wordbook: wordbook, next_review_at: 1.day.from_now)
+
+      get "/api/v1/wordbooks/#{wordbook.id}/test/words", headers: headers
+
+      expect(response.parsed_body["words"].size).to eq(0)
+    end
+
+    it "returns meanings and examples sorted by display_order" do
+      word = create(:word, wordbook: wordbook, next_review_at: nil)
+      create(:meaning, word: word, content: "second", display_order: 2)
+      create(:meaning, word: word, content: "first", display_order: 1)
+      create(:example, word: word, sentence: "Second", display_order: 2)
+      create(:example, word: word, sentence: "First", display_order: 1)
+
+      get "/api/v1/wordbooks/#{wordbook.id}/test/words", headers: headers
+
+      returned_word = response.parsed_body["words"].first
+      expect(returned_word["meanings"].map { |m| m["content"] }).to eq(%w[first second])
+      expect(returned_word["examples"].map { |e| e["sentence"] }).to eq(%w[First Second])
+    end
+
+    it "returns empty words array when no reviewable words exist" do
+      create(:word, wordbook: wordbook, next_review_at: 1.day.from_now)
+
+      get "/api/v1/wordbooks/#{wordbook.id}/test/words", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["words"]).to eq([])
+    end
+
+    it "returns 401 without authentication" do
+      get "/api/v1/wordbooks/#{wordbook.id}/test/words"
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns not_found for another user's wordbook" do
+      other_wordbook = create(:wordbook)
+
+      get "/api/v1/wordbooks/#{other_wordbook.id}/test/words", headers: headers
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -69,6 +69,64 @@ RSpec.describe "Api::V1::Words", type: :request do
 
       expect(response).to have_http_status(:not_found)
     end
+
+    context "with include parameter" do
+      let(:word) { create(:word, wordbook: wordbook) }
+
+      before do
+        create(:meaning, word: word, content: "meaning1", display_order: 2)
+        create(:meaning, word: word, content: "meaning2", display_order: 1)
+        create(:example, word: word, sentence: "Example1", display_order: 2)
+        create(:example, word: word, sentence: "Example2", display_order: 1)
+      end
+
+      it "includes meanings when include=meanings" do
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=meanings", headers: headers
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["meanings"].size).to eq(2)
+        expect(body["meanings"].map { |m| m["content"] }).to eq(%w[meaning2 meaning1])
+        expect(body).not_to have_key("examples")
+      end
+
+      it "includes examples when include=examples" do
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=examples", headers: headers
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["examples"].size).to eq(2)
+        expect(body["examples"].map { |e| e["sentence"] }).to eq(%w[Example2 Example1])
+        expect(body).not_to have_key("meanings")
+      end
+
+      it "includes both when include=meanings,examples" do
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=meanings,examples", headers: headers
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["meanings"].size).to eq(2)
+        expect(body["examples"].size).to eq(2)
+      end
+
+      it "ignores invalid include values" do
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=wordbook,invalid", headers: headers
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body).not_to have_key("wordbook")
+        expect(body).not_to have_key("invalid")
+      end
+
+      it "returns standard response without include parameter" do
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}", headers: headers
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body).not_to have_key("meanings")
+        expect(body).not_to have_key("examples")
+      end
+    end
   end
 
   describe "POST /api/v1/wordbooks/:wordbook_id/words" do

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -16,6 +16,26 @@ RSpec.describe "Api::V1::Words", type: :request do
       expect(response.parsed_body.size).to eq(3)
     end
 
+    it "includes first_meaning for each word" do
+      word = create(:word, wordbook: wordbook)
+      create(:meaning, word: word, content: "second", display_order: 2)
+      create(:meaning, word: word, content: "first", display_order: 1)
+
+      get "/api/v1/wordbooks/#{wordbook.id}/words", headers: headers
+
+      returned_word = response.parsed_body.find { |w| w["id"] == word.id }
+      expect(returned_word["first_meaning"]["content"]).to eq("first")
+      expect(returned_word["first_meaning"]["display_order"]).to eq(1)
+    end
+
+    it "returns null first_meaning when word has no meanings" do
+      create(:word, wordbook: wordbook)
+
+      get "/api/v1/wordbooks/#{wordbook.id}/words", headers: headers
+
+      expect(response.parsed_body.first["first_meaning"]).to be_nil
+    end
+
     it "returns 401 without authentication" do
       get "/api/v1/wordbooks/#{wordbook.id}/words"
 


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/wordbooks/:wordbook_id/test/words` endpoint that returns reviewable words with eager-loaded meanings and examples (42 requests → 1)
- Include `first_meaning` in `GET /wordbooks/:wordbook_id/words` response (N+1 requests → 1)
- Support `?include=meanings,examples` query param on `GET /wordbooks/:wordbook_id/words/:id` (3 requests → 1)

## Changes

- `Word` model: add `has_one :first_meaning` association and `scope :reviewable`
- New `Api::V1::Test::WordsController` for test page data
- `WordsController#index`: eager load and include `first_meaning`
- `WordsController#show`: parse `include` param to embed meanings/examples
- OpenAPI spec updated with new schemas and endpoint

## Test plan

- [x] `bundle exec rspec` — all 147 specs pass
- [x] Verify `GET /wordbooks/:id/test/words` returns only reviewable words with nested data
- [x] Verify `GET /wordbooks/:id/words` includes `first_meaning`
- [x] Verify `GET /wordbooks/:id/words/:id?include=meanings,examples` returns nested data
- [x] Verify `GET /wordbooks/:id/words/:id` (without include) returns same shape as before