### PR TITLE
Fix YAML syntax error in OpenAPI spec

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -314,7 +314,7 @@ paths:
         - name: include
           in: query
           required: false
-          description: Comma-separated list of relations to include. Allowed values: meanings, examples.
+          description: "Comma-separated list of relations to include. Allowed values: meanings, examples."
           schema:
             type: string
             example: meanings,examples


### PR DESCRIPTION
## Summary

- Fix YAML syntax error in `docs/openapi.yaml` that prevented the file from being rendered in OpenAPI (Swagger) Editor
- The `description` field for the `include` query parameter contained an unquoted colon (`Allowed values: meanings, examples.`), which was misinterpreted as a YAML mapping key

## Changes

- Quote the `description` value on line 317 to prevent YAML parsing failure
