### PR TITLE
chore: replace rubocop-rails-omakase with general RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,53 @@
-# Omakase Ruby styling for Rails
-inherit_gem: { rubocop-rails-omakase: rubocop.yml }
+plugins:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-rspec
 
-# Overwrite or add rules to create your own house style
-#
-# # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
-# Layout/SpaceInsideArrayLiteralBrackets:
-#   Enabled: false
+AllCops:
+  NewCops: enable
+  SuggestExtensions: false
+  TargetRubyVersion: 3.3
+  Exclude:
+    - "bin/**/*"
+    - "db/schema.rb"
+    - "vendor/**/*"
+    - "node_modules/**/*"
+
+# Metrics - disabled to avoid noisy false positives
+Metrics:
+  Enabled: false
+
+# Naming - disabled to avoid noisy false positives
+Naming:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# RSpec cops - relax strict defaults
+RSpec/MultipleExpectations:
+  Max: 10
+
+RSpec/ExampleLength:
+  Max: 15
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+RSpec/NestedGroups:
+  Max: 5
+
+RSpec/LetSetup:
+  Enabled: false
+
+# Migrations - exclude from bulk change and squished SQL checks
+Rails/BulkChangeTable:
+  Exclude:
+    - "db/migrate/**/*"
+
+Rails/SquishedSQLHeredocs:
+  Exclude:
+    - "db/migrate/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-gem "rails", "~> 8.1.0"
+gem 'rails', '~> 8.1.0'
 # Use postgresql as the database for Active Record
-gem "pg", "~> 1.1"
+gem 'pg', '~> 1.1'
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", ">= 5.0"
+gem 'puma', '>= 5.0'
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 # gem "jbuilder"
 
@@ -13,50 +13,53 @@ gem "puma", ">= 5.0"
 # gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ windows jruby ]
+gem 'tzinfo-data', platforms: %i[windows jruby]
 
 # Use the database-backed adapters for Rails.cache and Active Job
-gem "solid_cache"
-gem "solid_queue"
+gem 'solid_cache'
+gem 'solid_queue'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", require: false
+gem 'bootsnap', require: false
 
 # Deploy this application anywhere as a Docker container [https://kamal-deploy.org]
-gem "kamal", require: false
+gem 'kamal', require: false
 
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
-gem "thruster", require: false
+gem 'thruster', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 
 # Google authentication library for ID token verification
-gem "googleauth"
+gem 'googleauth'
 
 # JWT token generation and verification
-gem "jwt"
+gem 'jwt'
 
-gem "openssl"
+gem 'openssl'
 
 group :development, :test do
   # Load environment variables from .env file
-  gem "dotenv-rails"
+  gem 'dotenv-rails'
 
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
+  gem 'debug', platforms: %i[mri windows], require: 'debug/prelude'
 
   # Audits gems for known security defects (use config/bundler-audit.yml to ignore issues)
-  gem "bundler-audit", require: false
+  gem 'bundler-audit', require: false
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", require: false
+  gem 'brakeman', require: false
 
-  # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
-  gem "rubocop-rails-omakase", require: false
+  # Ruby linting and style checking
+  gem 'rubocop', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
 
   # Testing
-  gem "rspec-rails"
-  gem "factory_bot_rails"
-  gem "shoulda-matchers"
+  gem 'factory_bot_rails'
+  gem 'rspec-rails'
+  gem 'shoulda-matchers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,10 +325,9 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.44.0, < 2.0)
-    rubocop-rails-omakase (1.1.0)
-      rubocop (>= 1.72)
-      rubocop-performance (>= 1.24)
-      rubocop-rails (>= 2.30)
+    rubocop-rspec (3.9.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     shoulda-matchers (7.0.1)
@@ -405,7 +404,10 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.1.0)
   rspec-rails
-  rubocop-rails-omakase
+  rubocop
+  rubocop-performance
+  rubocop-rails
+  rubocop-rspec
   shoulda-matchers
   solid_cache
   solid_queue

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative "config/application"
+require_relative 'config/application'
 
 Rails.application.load_tasks

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -7,55 +7,57 @@ module Api
       skip_before_action :authenticate_user!
 
       def guest
-        user = User.create!(provider: "guest", guest_expires_at: 7.days.from_now)
+        user = User.create!(provider: 'guest', guest_expires_at: 7.days.from_now)
         token = encode_jwt(user.id, expires_at: user.guest_expires_at)
 
-        render json: { user: user.as_json(only: [ :guest_expires_at ]), token: token }, status: :created
+        render json: { user: user.as_json(only: [:guest_expires_at]), token: token }, status: :created
       end
 
       def google
-        id_token = request.headers["Authorization"]&.split("Bearer ")&.last
+        id_token = request.headers['Authorization']&.split('Bearer ')&.last
 
-        return render json: { error: "Authorization header missing" }, status: :bad_request if id_token.blank?
+        return render json: { error: 'Authorization header missing' }, status: :bad_request if id_token.blank?
 
         payload = verify_google_token(id_token)
 
-        return render json: { error: "Invalid ID token" }, status: :unauthorized unless payload
+        return render json: { error: 'Invalid ID token' }, status: :unauthorized unless payload
 
-        if params[:guest_token].present?
-          return handle_guest_migration(payload)
-        end
+        return handle_guest_migration(payload) if params[:guest_token].present?
 
-        email = payload["email"]
+        email = payload['email']
         existing_user = User.find_by(email: email) if email.present?
 
-        if existing_user && existing_user.provider != "google"
-          return render json: {
-            error: "This email is already registered with #{existing_user.provider}. Please sign in with #{existing_user.provider}."
-          }, status: :conflict
+        if existing_user && existing_user.provider != 'google'
+          message = "This email is already registered with #{existing_user.provider}. " \
+                    "Please sign in with #{existing_user.provider}."
+          return render json: { error: message }, status: :conflict
         end
 
-        user = User.find_or_create_by(provider: "google", provider_uid: payload["sub"]) do |u|
+        user = User.find_or_create_by(provider: 'google', provider_uid: payload['sub']) do |u|
           u.email = email
-          u.name = payload["name"]
-          u.avatar_url = payload["picture"]
+          u.name = payload['name']
+          u.avatar_url = payload['picture']
         end
 
-        render json: { user: user.as_json(only: [ :email, :name, :avatar_url ]), token: encode_jwt(user.id) }, status: :ok
+        render json: { user: user.as_json(only: %i[email name avatar_url]), token: encode_jwt(user.id) },
+               status: :ok
       end
+
       private
 
       def handle_guest_migration(google_payload)
         guest_user = find_guest_user_from_token(params[:guest_token])
 
-        return render json: { error: "Invalid guest token" }, status: :unauthorized unless guest_user
+        return render json: { error: 'Invalid guest token' }, status: :unauthorized unless guest_user
 
         result = migrate_guest_to_google(guest_user, google_payload)
 
         if result[:success]
-          render json: { user: result[:user].as_json(only: [ :email, :name, :avatar_url ]), token: encode_jwt(result[:user].id) }, status: :ok
+          user_json = result[:user].as_json(only: %i[email name avatar_url])
+          render json: { user: user_json, token: encode_jwt(result[:user].id) },
+                 status: :ok
         else
-          render json: { error: result[:error] }, status: :unprocessable_entity
+          render json: { error: result[:error] }, status: :unprocessable_content
         end
       end
     end

--- a/app/controllers/api/v1/examples_controller.rb
+++ b/app/controllers/api/v1/examples_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class ExamplesController < ApplicationController
       before_action :set_word
-      before_action :set_example, only: [ :show, :update, :destroy ]
+      before_action :set_example, only: %i[show update destroy]
 
       def index
         examples = @word.examples
@@ -19,7 +19,7 @@ module Api
         if example.save
           render json: example, status: :created
         else
-          render json: { errors: example.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: example.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -27,7 +27,7 @@ module Api
         if @example.update(example_params)
           render json: @example
         else
-          render json: { errors: @example.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @example.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -47,7 +47,7 @@ module Api
       end
 
       def example_params
-        params.require(:example).permit(:sentence, :translation, :display_order)
+        params.expect(example: %i[sentence translation display_order])
       end
     end
   end

--- a/app/controllers/api/v1/meanings_controller.rb
+++ b/app/controllers/api/v1/meanings_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class MeaningsController < ApplicationController
       before_action :set_word
-      before_action :set_meaning, only: [ :show, :update, :destroy ]
+      before_action :set_meaning, only: %i[show update destroy]
 
       def index
         meanings = @word.meanings
@@ -19,7 +19,7 @@ module Api
         if meaning.save
           render json: meaning, status: :created
         else
-          render json: { errors: meaning.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: meaning.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -27,7 +27,7 @@ module Api
         if @meaning.update(meaning_params)
           render json: @meaning
         else
-          render json: { errors: @meaning.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @meaning.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -47,7 +47,7 @@ module Api
       end
 
       def meaning_params
-        params.require(:meaning).permit(:content, :display_order)
+        params.expect(meaning: %i[content display_order])
       end
     end
   end

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class SettingsController < ApplicationController
-      before_action :set_setting, only: [ :show, :update, :destroy ]
+      before_action :set_setting, only: %i[show update destroy]
 
       def show
         render json: setting_response(@setting)
@@ -13,7 +13,7 @@ module Api
         if setting.save
           render json: setting_response(setting), status: :created
         else
-          render json: { errors: setting.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: setting.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -21,7 +21,7 @@ module Api
         if @setting.update(build_setting_params)
           render json: setting_response(@setting)
         else
-          render json: { errors: @setting.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @setting.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -38,10 +38,10 @@ module Api
       end
 
       def setting_params
-        params.require(:setting).permit(
-          hard_interval: [ :days, :hours, :minutes ],
-          uncertain_interval: [ :days, :hours, :minutes ],
-          easy_interval: [ :days, :hours, :minutes ]
+        params.expect(
+          setting: [hard_interval: %i[days hours minutes],
+                    uncertain_interval: %i[days hours minutes],
+                    easy_interval: %i[days hours minutes]]
         )
       end
 
@@ -78,8 +78,8 @@ module Api
         return nil if duration.blank?
 
         total_seconds = duration.to_i
-        days = total_seconds / 86400
-        hours = (total_seconds % 86400) / 3600
+        days = total_seconds / 86_400
+        hours = (total_seconds % 86_400) / 3600
         minutes = (total_seconds % 3600) / 60
 
         { days: days, hours: hours, minutes: minutes }

--- a/app/controllers/api/v1/test/words_controller.rb
+++ b/app/controllers/api/v1/test/words_controller.rb
@@ -7,13 +7,13 @@ module Api
           words = wordbook.words.reviewable.includes(:meanings, :examples)
 
           render json: {
-            wordbook: wordbook.as_json(only: [ :id, :title ]),
-            words: words.map { |word|
+            wordbook: wordbook.as_json(only: %i[id title]),
+            words: words.map do |word|
               word.as_json.merge(
                 meanings: word.meanings.sort_by(&:display_order).as_json,
                 examples: word.examples.sort_by(&:display_order).as_json
               )
-            }
+            end
           }
         end
       end

--- a/app/controllers/api/v1/wordbooks_controller.rb
+++ b/app/controllers/api/v1/wordbooks_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class WordbooksController < ApplicationController
-      before_action :set_wordbook, only: [ :show, :update, :destroy ]
+      before_action :set_wordbook, only: %i[show update destroy]
 
       def index
         wordbooks = current_user.wordbooks
@@ -18,7 +18,7 @@ module Api
         if wordbook.save
           render json: wordbook, status: :created
         else
-          render json: { errors: wordbook.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: wordbook.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -26,7 +26,7 @@ module Api
         if @wordbook.update(wordbook_params)
           render json: @wordbook
         else
-          render json: { errors: @wordbook.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @wordbook.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -42,7 +42,7 @@ module Api
       end
 
       def wordbook_params
-        params.require(:wordbook).permit(:title)
+        params.expect(wordbook: [:title])
       end
     end
   end

--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class WordsController < ApplicationController
       before_action :set_wordbook
-      before_action :set_word, only: [ :show, :update, :destroy ]
+      before_action :set_word, only: %i[show update destroy]
 
       def index
         words = @wordbook.words.includes(:first_meaning)
@@ -13,9 +13,7 @@ module Api
 
       def show
         includes = parse_includes
-        if includes.any?
-          @word = @wordbook.words.includes(*includes.map(&:to_sym)).find(params[:id])
-        end
+        @word = @wordbook.words.includes(*includes.map(&:to_sym)).find(params[:id]) if includes.any?
         render json: word_json(@word, includes: includes)
       end
 
@@ -25,7 +23,7 @@ module Api
         if word.save
           render json: word, status: :created
         else
-          render json: { errors: word.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: word.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -33,7 +31,7 @@ module Api
         if @word.update(word_params)
           render json: @word
         else
-          render json: { errors: @word.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: @word.errors.full_messages }, status: :unprocessable_content
         end
       end
 
@@ -41,6 +39,8 @@ module Api
         @word.destroy
         head :no_content
       end
+
+      ALLOWED_INCLUDES = %w[meanings examples].freeze
 
       private
 
@@ -52,11 +52,10 @@ module Api
         @word = @wordbook.words.find(params[:id])
       end
 
-      ALLOWED_INCLUDES = %w[meanings examples].freeze
-
       def parse_includes
         return [] if params[:include].blank?
-        params[:include].split(",").map(&:strip).select { |i| ALLOWED_INCLUDES.include?(i) }
+
+        params[:include].split(',').map(&:strip).select { |i| ALLOWED_INCLUDES.include?(i) }
       end
 
       def word_json(word, includes: [])
@@ -68,7 +67,7 @@ module Api
       end
 
       def word_params
-        params.require(:word).permit(:spelling, :status, :next_review_at)
+        params.expect(word: %i[spelling status next_review_at])
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,16 +5,16 @@ class ApplicationController < ActionController::API
     rescue_from StandardError do |e|
       Rails.logger.error("Unhandled error: #{e.class} - #{e.message}")
       Rails.logger.error(e.backtrace&.first(10)&.join("\n"))
-      render json: { error: "Internal server error" }, status: :internal_server_error
+      render json: { error: 'Internal server error' }, status: :internal_server_error
     end
   end
 
   rescue_from ActiveRecord::RecordNotFound do
-    render json: { error: "Not found" }, status: :not_found
+    render json: { error: 'Not found' }, status: :not_found
   end
 
   rescue_from ActiveRecord::RecordNotUnique do
-    render json: { error: "Duplicate record" }, status: :conflict
+    render json: { error: 'Duplicate record' }, status: :conflict
   end
 
   rescue_from ActionController::ParameterMissing do |e|

--- a/app/controllers/concerns/authenticatable.rb
+++ b/app/controllers/concerns/authenticatable.rb
@@ -10,13 +10,13 @@ module Authenticatable
   private
 
   def authenticate_user!
-    token = request.headers["Authorization"]&.split("Bearer ")&.last
+    token = request.headers['Authorization']&.split('Bearer ')&.last
     return render_unauthorized unless token
 
     payload = decode_jwt(token)
     return render_unauthorized unless payload
 
-    @current_user = User.find_by(id: payload["sub"])
+    @current_user = User.find_by(id: payload['sub'])
     render_unauthorized unless @current_user
   end
 
@@ -25,6 +25,6 @@ module Authenticatable
   end
 
   def render_unauthorized
-    render json: { error: "Unauthorized" }, status: :unauthorized
+    render json: { error: 'Unauthorized' }, status: :unauthorized
   end
 end

--- a/app/controllers/concerns/google_authenticatable.rb
+++ b/app/controllers/concerns/google_authenticatable.rb
@@ -4,7 +4,7 @@ module GoogleAuthenticatable
   private
 
   def verify_google_token(token)
-    client_id = ENV["GOOGLE_CLIENT_ID"]
+    client_id = ENV.fetch('GOOGLE_CLIENT_ID', nil)
 
     begin
       Google::Auth::IDTokens.verify_oidc(token, aud: client_id)

--- a/app/controllers/concerns/guest_migratable.rb
+++ b/app/controllers/concerns/guest_migratable.rb
@@ -7,14 +7,14 @@ module GuestMigratable
     payload = decode_jwt(token)
     return nil unless payload
 
-    User.find_by(id: payload["sub"], provider: "guest")
+    User.find_by(id: payload['sub'], provider: 'guest')
   end
 
   def migrate_guest_to_google(guest_user, google_payload)
-    return { success: false, user: nil, error: "User is not a guest" } unless guest_user.guest?
+    return { success: false, user: nil, error: 'User is not a guest' } unless guest_user.guest?
 
     ActiveRecord::Base.transaction do
-      existing_google_user = User.find_by(provider: "google", provider_uid: google_payload["sub"])
+      existing_google_user = User.find_by(provider: 'google', provider_uid: google_payload['sub'])
 
       if existing_google_user
         merge_guest_into_google_user(guest_user, existing_google_user)
@@ -26,11 +26,11 @@ module GuestMigratable
 
   def convert_guest_to_google(guest_user, google_payload)
     guest_user.update!(
-      provider: "google",
-      provider_uid: google_payload["sub"],
-      email: google_payload["email"],
-      name: google_payload["name"],
-      avatar_url: google_payload["picture"],
+      provider: 'google',
+      provider_uid: google_payload['sub'],
+      email: google_payload['email'],
+      name: google_payload['name'],
+      avatar_url: google_payload['picture'],
       guest_expires_at: nil
     )
 
@@ -38,11 +38,9 @@ module GuestMigratable
   end
 
   def merge_guest_into_google_user(guest_user, google_user)
-    guest_user.wordbooks.update_all(user_id: google_user.id)
+    guest_user.wordbooks.update_all(user_id: google_user.id) # rubocop:disable Rails/SkipsModelValidations
 
-    if guest_user.setting.present? && google_user.setting.blank?
-      guest_user.setting.update!(user_id: google_user.id)
-    end
+    guest_user.setting.update!(user_id: google_user.id) if guest_user.setting.present? && google_user.setting.blank?
 
     guest_user.reload.destroy!
 

--- a/app/controllers/concerns/jwt_authenticatable.rb
+++ b/app/controllers/concerns/jwt_authenticatable.rb
@@ -9,11 +9,11 @@ module JwtAuthenticatable
       exp: expires_at.to_i,
       iat: Time.current.to_i
     }
-    JWT.encode(payload, jwt_secret_key, "HS256")
+    JWT.encode(payload, jwt_secret_key, 'HS256')
   end
 
   def decode_jwt(token)
-    decoded = JWT.decode(token, jwt_secret_key, true, algorithm: "HS256")
+    decoded = JWT.decode(token, jwt_secret_key, true, algorithm: 'HS256')
     decoded.first
   rescue JWT::ExpiredSignature, JWT::DecodeError
     nil

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -11,8 +11,9 @@ class Setting < ApplicationRecord
       value = send(attr)
       next if value.blank?
 
-      unless value.is_a?(ActiveSupport::Duration) && value.to_i > 0
-        errors.add(attr, "must be a positive interval")
+      unless value.is_a?(ActiveSupport::Duration) && value.to_i.positive?
+        errors.add(attr,
+                   'must be a positive interval')
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: { allow_nil: true }
   validates :provider, presence: true
   validates :provider_uid, presence: true, uniqueness: { scope: :provider }, unless: -> { guest? }
-  validates :guest_expires_at, presence: true, if: -> { provider == "guest" }
+  validates :guest_expires_at, presence: true, if: -> { provider == 'guest' }
 
-  enum :provider, { google: "google", guest: "guest" }
+  enum :provider, { google: 'google', guest: 'guest' }
 end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -2,12 +2,12 @@ class Word < ApplicationRecord
   belongs_to :wordbook
   has_many :meanings, dependent: :destroy
   has_many :examples, dependent: :destroy
-  has_one :first_meaning, -> { order(:display_order) }, class_name: "Meaning"
+  has_one :first_meaning, -> { order(:display_order) }, class_name: 'Meaning', dependent: nil, inverse_of: false
 
   validates :spelling, presence: true
   validates :status, presence: true
 
-  enum :status, { not_studied: "not_studied", hard: "hard", uncertain: "uncertain", easy: "easy" }
+  enum :status, { not_studied: 'not_studied', hard: 'hard', uncertain: 'uncertain', easy: 'easy' }
 
-  scope :reviewable, -> { where("next_review_at IS NULL OR next_review_at <= ?", Time.current) }
+  scope :reviewable, -> { where('next_review_at IS NULL OR next_review_at <= ?', Time.current) }
 end

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative "config/environment"
+require_relative 'config/environment'
 
 run Rails.application
 Rails.application.load_server

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,16 +1,16 @@
-require_relative "boot"
+require_relative 'boot'
 
-require "rails"
+require 'rails'
 # Pick the frameworks you want:
-require "active_model/railtie"
-require "active_job/railtie"
-require "active_record/railtie"
+require 'active_model/railtie'
+require 'active_job/railtie'
+require 'active_record/railtie'
 # require "active_storage/engine"
-require "action_controller/railtie"
+require 'action_controller/railtie'
 # require "action_mailer/railtie"
 # require "action_mailbox/engine"
 # require "action_text/engine"
-require "action_view/railtie"
+require 'action_view/railtie'
 # require "action_cable/engine"
 # require "rails/test_unit/railtie"
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require "bundler/setup" # Set up gems listed in the Gemfile.
-require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -1,14 +1,14 @@
 # Run using bin/ci
 
 CI.run do
-  step "Setup", "bin/setup --skip-server"
+  step 'Setup', 'bin/setup --skip-server'
 
-  step "Style: Ruby", "bin/rubocop"
+  step 'Style: Ruby', 'bin/rubocop'
 
-  step "Security: Gem audit", "bin/bundler-audit"
-  step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
-  step "Tests: Rails", "bin/rails test"
-  step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
+  step 'Security: Gem audit', 'bin/bundler-audit'
+  step 'Security: Brakeman code analysis', 'bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error'
+  step 'Tests: Rails', 'bin/rails test'
+  step 'Tests: Seeds', 'env RAILS_ENV=test bin/rails db:seed:replant'
 
   # Optional: set a green GitHub commit status to unblock PR merge.
   # Requires the `gh` CLI and `gh extension install basecamp/gh-signoff`.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative "application"
+require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -17,8 +17,8 @@ Rails.application.configure do
 
   # Enable/disable Action Controller caching. By default Action Controller caching is disabled.
   # Run rails dev:cache to toggle Action Controller caching.
-  if Rails.root.join("tmp/caching-dev.txt").exist?
-    config.public_file_server.headers = { "cache-control" => "public, max-age=#{2.days.to_i}" }
+  if Rails.root.join('tmp/caching-dev.txt').exist?
+    config.public_file_server.headers = { 'cache-control' => "public, max-age=#{2.days.to_i}" }
   else
     config.action_controller.perform_caching = false
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.consider_all_requests_local = false
 
   # Cache assets for far-future expiry since they are all digest stamped.
-  config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
+  config.public_file_server.headers = { 'cache-control' => "public, max-age=#{1.year.to_i}" }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
@@ -28,14 +28,14 @@ Rails.application.configure do
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
-  config.log_tags = [ :request_id ]
-  config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
+  config.log_tags = [:request_id]
+  config.logger   = ActiveSupport::TaggedLogging.logger($stdout)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!).
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
 
   # Prevent health checks from clogging up the logs.
-  config.silence_healthcheck_path = "/up"
+  config.silence_healthcheck_path = '/up'
 
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
@@ -55,7 +55,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Only use :id for inspections in production.
-  config.active_record.attributes_for_inspect = [ :id ]
+  config.active_record.attributes_for_inspect = [:id]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,10 +13,10 @@ Rails.application.configure do
   # this is usually not necessary, and can slow down your test suite. However, it's
   # recommended that you enable it in continuous integration systems to ensure eager
   # loading is working properly before deploying your code.
-  config.eager_load = ENV["CI"].present?
+  config.eager_load = ENV['CI'].present?
 
   # Configure public file server for tests with cache-control for performance.
-  config.public_file_server.headers = { "cache-control" => "public, max-age=3600" }
+  config.public_file_server.headers = { 'cache-control' => 'public, max-age=3600' }
 
   # Show full error reports.
   config.consider_all_requests_local = true

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,6 +3,6 @@
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
-Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
+Rails.application.config.filter_parameters += %i[
+  passw email secret token _key crypt salt certificate otp ssn cvv cvc
 ]

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -25,18 +25,18 @@
 # Any libraries that use a connection pool or another resource pool should
 # be configured to provide at least as many connections as the number of
 # threads. This includes Active Record's `pool` parameter in `database.yml`.
-threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
+threads_count = ENV.fetch('RAILS_MAX_THREADS', 3)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT", 3000)
+port ENV.fetch('PORT', 3000)
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 
 # Run the Solid Queue supervisor inside of Puma for single-server deployments.
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
+plugin :solid_queue if ENV['SOLID_QUEUE_IN_PUMA']
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
-pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
+pidfile ENV['PIDFILE'] if ENV['PIDFILE']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,26 +3,26 @@ Rails.application.routes.draw do
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
+  get 'up' => 'rails/health#show', as: :rails_health_check
 
   # API v1
   namespace :api do
     namespace :v1 do
       # Authentication
-      post "auth/guest", to: "auth#guest"
-      post "auth/google", to: "auth#google"
+      post 'auth/guest', to: 'auth#guest'
+      post 'auth/google', to: 'auth#google'
 
       # Resources
       resources :wordbooks do
         namespace :test do
-          resources :words, only: [ :index ]
+          resources :words, only: [:index]
         end
         resources :words do
           resources :meanings
           resources :examples
         end
       end
-      resource :setting, only: [ :show, :create, :update, :destroy ]
+      resource :setting, only: %i[show create update destroy]
     end
   end
 

--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -1,12 +1,12 @@
 ActiveRecord::Schema[7.2].define(version: 1) do
-  create_table "solid_cache_entries", force: :cascade do |t|
-    t.binary "key", limit: 1024, null: false
-    t.binary "value", limit: 536870912, null: false
-    t.datetime "created_at", null: false
-    t.integer "key_hash", limit: 8, null: false
-    t.integer "byte_size", limit: 4, null: false
-    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
-    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
-    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
+  create_table 'solid_cache_entries', force: :cascade do |t|
+    t.binary 'key', limit: 1024, null: false
+    t.binary 'value', limit: 536_870_912, null: false
+    t.datetime 'created_at', null: false
+    t.integer 'key_hash', limit: 8, null: false
+    t.integer 'byte_size', limit: 4, null: false
+    t.index ['byte_size'], name: 'index_solid_cache_entries_on_byte_size'
+    t.index %w[key_hash byte_size], name: 'index_solid_cache_entries_on_key_hash_and_byte_size'
+    t.index ['key_hash'], name: 'index_solid_cache_entries_on_key_hash', unique: true
   end
 end

--- a/db/migrate/20260217134142_update_users_schema_to_match_er_diagram.rb
+++ b/db/migrate/20260217134142_update_users_schema_to_match_er_diagram.rb
@@ -4,12 +4,12 @@ class UpdateUsersSchemaToMatchErDiagram < ActiveRecord::Migration[8.1]
     rename_column :users, :google_id, :provider_uid
 
     # provider カラムを追加（必須）
-    add_column :users, :provider, :string, null: false, default: "google"
+    add_column :users, :provider, :string, null: false, default: 'google'
 
     # guest_expires_at カラムを追加
     add_column :users, :guest_expires_at, :datetime
 
     # デフォルト値を削除（既存データに適用済み）
-    change_column_default :users, :provider, from: "google", to: nil
+    change_column_default :users, :provider, from: 'google', to: nil
   end
 end

--- a/db/migrate/20260219142721_add_unique_index_to_users_provider_and_provider_uid.rb
+++ b/db/migrate/20260219142721_add_unique_index_to_users_provider_and_provider_uid.rb
@@ -1,5 +1,5 @@
 class AddUniqueIndexToUsersProviderAndProviderUid < ActiveRecord::Migration[8.1]
   def change
-    add_index :users, [ :provider, :provider_uid ], unique: true, name: "index_users_on_provider_and_provider_uid"
+    add_index :users, %i[provider provider_uid], unique: true, name: 'index_users_on_provider_and_provider_uid'
   end
 end

--- a/db/migrate/20260222131840_add_check_constraint_guest_expires_at.rb
+++ b/db/migrate/20260222131840_add_check_constraint_guest_expires_at.rb
@@ -1,7 +1,7 @@
 class AddCheckConstraintGuestExpiresAt < ActiveRecord::Migration[8.1]
   def change
     add_check_constraint :users,
-      "provider != 'guest' OR guest_expires_at IS NOT NULL",
-      name: "check_guest_expires_at_presence"
+                         "provider != 'guest' OR guest_expires_at IS NOT NULL",
+                         name: 'check_guest_expires_at_presence'
   end
 end

--- a/db/migrate/20260226141209_change_intervals_to_interval_type.rb
+++ b/db/migrate/20260226141209_change_intervals_to_interval_type.rb
@@ -5,7 +5,7 @@ class ChangeIntervalsToIntervalType < ActiveRecord::Migration[8.1]
     add_column :settings, :uncertain_interval, :interval
     add_column :settings, :easy_interval, :interval
 
-    execute <<~SQL
+    execute <<~SQL.squish
       UPDATE settings
       SET hard_interval = make_interval(days => hard_interval_days),
           uncertain_interval = make_interval(days => uncertain_interval_days),
@@ -34,7 +34,7 @@ class ChangeIntervalsToIntervalType < ActiveRecord::Migration[8.1]
     add_column :settings, :uncertain_interval_days, :integer
     add_column :settings, :easy_interval_days, :integer
 
-    execute <<~SQL
+    execute <<~SQL.squish
       UPDATE settings
       SET hard_interval_days = EXTRACT(EPOCH FROM hard_interval) / 86400,
           uncertain_interval_days = EXTRACT(EPOCH FROM uncertain_interval) / 86400,

--- a/db/migrate/20260227024502_add_check_constraint_to_words_status.rb
+++ b/db/migrate/20260227024502_add_check_constraint_to_words_status.rb
@@ -1,15 +1,15 @@
 class AddCheckConstraintToWordsStatus < ActiveRecord::Migration[8.1]
   def up
-    execute <<~SQL
+    execute <<~SQL.squish
       UPDATE words SET status = 'not_studied' WHERE status NOT IN ('not_studied', 'hard', 'uncertain', 'easy')
     SQL
 
     add_check_constraint :words,
-      "status IN ('not_studied', 'hard', 'uncertain', 'easy')",
-      name: "check_words_status_values"
+                         "status IN ('not_studied', 'hard', 'uncertain', 'easy')",
+                         name: 'check_words_status_values'
   end
 
   def down
-    remove_check_constraint :words, name: "check_words_status_values"
+    remove_check_constraint :words, name: 'check_words_status_values'
   end
 end

--- a/db/migrate/20260227121940_add_check_constraint_to_users_provider.rb
+++ b/db/migrate/20260227121940_add_check_constraint_to_users_provider.rb
@@ -1,7 +1,7 @@
 class AddCheckConstraintToUsersProvider < ActiveRecord::Migration[8.1]
   def change
     add_check_constraint :users,
-      "provider IN ('google', 'guest')",
-      name: "check_users_provider_values"
+                         "provider IN ('google', 'guest')",
+                         name: 'check_users_provider_values'
   end
 end

--- a/db/migrate/20260320122208_make_provider_uid_nullable_for_guests.rb
+++ b/db/migrate/20260320122208_make_provider_uid_nullable_for_guests.rb
@@ -4,7 +4,7 @@ class MakeProviderUidNullableForGuests < ActiveRecord::Migration[8.1]
 
     reversible do |dir|
       dir.up do
-        execute <<~SQL
+        execute <<~SQL.squish
           ALTER TABLE users
             ADD CONSTRAINT chk_provider_uid_required_for_non_guest
             CHECK (provider = 'guest' OR provider_uid IS NOT NULL)
@@ -12,7 +12,7 @@ class MakeProviderUidNullableForGuests < ActiveRecord::Migration[8.1]
       end
 
       dir.down do
-        execute <<~SQL
+        execute <<~SQL.squish
           ALTER TABLE users
             DROP CONSTRAINT chk_provider_uid_required_for_non_guest
         SQL

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -1,129 +1,130 @@
 ActiveRecord::Schema[7.1].define(version: 1) do
-  create_table "solid_queue_blocked_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
-    t.string "concurrency_key", null: false
-    t.datetime "expires_at", null: false
-    t.datetime "created_at", null: false
-    t.index [ "concurrency_key", "priority", "job_id" ], name: "index_solid_queue_blocked_executions_for_release"
-    t.index [ "expires_at", "concurrency_key" ], name: "index_solid_queue_blocked_executions_for_maintenance"
-    t.index [ "job_id" ], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  create_table 'solid_queue_blocked_executions', force: :cascade do |t|
+    t.bigint 'job_id', null: false
+    t.string 'queue_name', null: false
+    t.integer 'priority', default: 0, null: false
+    t.string 'concurrency_key', null: false
+    t.datetime 'expires_at', null: false
+    t.datetime 'created_at', null: false
+    t.index %w[concurrency_key priority job_id], name: 'index_solid_queue_blocked_executions_for_release'
+    t.index %w[expires_at concurrency_key], name: 'index_solid_queue_blocked_executions_for_maintenance'
+    t.index ['job_id'], name: 'index_solid_queue_blocked_executions_on_job_id', unique: true
   end
 
-  create_table "solid_queue_claimed_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.bigint "process_id"
-    t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
-    t.index [ "process_id", "job_id" ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  create_table 'solid_queue_claimed_executions', force: :cascade do |t|
+    t.bigint 'job_id', null: false
+    t.bigint 'process_id'
+    t.datetime 'created_at', null: false
+    t.index ['job_id'], name: 'index_solid_queue_claimed_executions_on_job_id', unique: true
+    t.index %w[process_id job_id], name: 'index_solid_queue_claimed_executions_on_process_id_and_job_id'
   end
 
-  create_table "solid_queue_failed_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.text "error"
-    t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  create_table 'solid_queue_failed_executions', force: :cascade do |t|
+    t.bigint 'job_id', null: false
+    t.text 'error'
+    t.datetime 'created_at', null: false
+    t.index ['job_id'], name: 'index_solid_queue_failed_executions_on_job_id', unique: true
   end
 
-  create_table "solid_queue_jobs", force: :cascade do |t|
-    t.string "queue_name", null: false
-    t.string "class_name", null: false
-    t.text "arguments"
-    t.integer "priority", default: 0, null: false
-    t.string "active_job_id"
-    t.datetime "scheduled_at"
-    t.datetime "finished_at"
-    t.string "concurrency_key"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index [ "active_job_id" ], name: "index_solid_queue_jobs_on_active_job_id"
-    t.index [ "class_name" ], name: "index_solid_queue_jobs_on_class_name"
-    t.index [ "finished_at" ], name: "index_solid_queue_jobs_on_finished_at"
-    t.index [ "queue_name", "finished_at" ], name: "index_solid_queue_jobs_for_filtering"
-    t.index [ "scheduled_at", "finished_at" ], name: "index_solid_queue_jobs_for_alerting"
+  create_table 'solid_queue_jobs', force: :cascade do |t|
+    t.string 'queue_name', null: false
+    t.string 'class_name', null: false
+    t.text 'arguments'
+    t.integer 'priority', default: 0, null: false
+    t.string 'active_job_id'
+    t.datetime 'scheduled_at'
+    t.datetime 'finished_at'
+    t.string 'concurrency_key'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['active_job_id'], name: 'index_solid_queue_jobs_on_active_job_id'
+    t.index ['class_name'], name: 'index_solid_queue_jobs_on_class_name'
+    t.index ['finished_at'], name: 'index_solid_queue_jobs_on_finished_at'
+    t.index %w[queue_name finished_at], name: 'index_solid_queue_jobs_for_filtering'
+    t.index %w[scheduled_at finished_at], name: 'index_solid_queue_jobs_for_alerting'
   end
 
-  create_table "solid_queue_pauses", force: :cascade do |t|
-    t.string "queue_name", null: false
-    t.datetime "created_at", null: false
-    t.index [ "queue_name" ], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  create_table 'solid_queue_pauses', force: :cascade do |t|
+    t.string 'queue_name', null: false
+    t.datetime 'created_at', null: false
+    t.index ['queue_name'], name: 'index_solid_queue_pauses_on_queue_name', unique: true
   end
 
-  create_table "solid_queue_processes", force: :cascade do |t|
-    t.string "kind", null: false
-    t.datetime "last_heartbeat_at", null: false
-    t.bigint "supervisor_id"
-    t.integer "pid", null: false
-    t.string "hostname"
-    t.text "metadata"
-    t.datetime "created_at", null: false
-    t.string "name", null: false
-    t.index [ "last_heartbeat_at" ], name: "index_solid_queue_processes_on_last_heartbeat_at"
-    t.index [ "name", "supervisor_id" ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
-    t.index [ "supervisor_id" ], name: "index_solid_queue_processes_on_supervisor_id"
+  create_table 'solid_queue_processes', force: :cascade do |t|
+    t.string 'kind', null: false
+    t.datetime 'last_heartbeat_at', null: false
+    t.bigint 'supervisor_id'
+    t.integer 'pid', null: false
+    t.string 'hostname'
+    t.text 'metadata'
+    t.datetime 'created_at', null: false
+    t.string 'name', null: false
+    t.index ['last_heartbeat_at'], name: 'index_solid_queue_processes_on_last_heartbeat_at'
+    t.index %w[name supervisor_id], name: 'index_solid_queue_processes_on_name_and_supervisor_id', unique: true
+    t.index ['supervisor_id'], name: 'index_solid_queue_processes_on_supervisor_id'
   end
 
-  create_table "solid_queue_ready_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_ready_executions_on_job_id", unique: true
-    t.index [ "priority", "job_id" ], name: "index_solid_queue_poll_all"
-    t.index [ "queue_name", "priority", "job_id" ], name: "index_solid_queue_poll_by_queue"
+  create_table 'solid_queue_ready_executions', force: :cascade do |t|
+    t.bigint 'job_id', null: false
+    t.string 'queue_name', null: false
+    t.integer 'priority', default: 0, null: false
+    t.datetime 'created_at', null: false
+    t.index ['job_id'], name: 'index_solid_queue_ready_executions_on_job_id', unique: true
+    t.index %w[priority job_id], name: 'index_solid_queue_poll_all'
+    t.index %w[queue_name priority job_id], name: 'index_solid_queue_poll_by_queue'
   end
 
-  create_table "solid_queue_recurring_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "task_key", null: false
-    t.datetime "run_at", null: false
-    t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
-    t.index [ "task_key", "run_at" ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  create_table 'solid_queue_recurring_executions', force: :cascade do |t|
+    t.bigint 'job_id', null: false
+    t.string 'task_key', null: false
+    t.datetime 'run_at', null: false
+    t.datetime 'created_at', null: false
+    t.index ['job_id'], name: 'index_solid_queue_recurring_executions_on_job_id', unique: true
+    t.index %w[task_key run_at], name: 'index_solid_queue_recurring_executions_on_task_key_and_run_at',
+                                 unique: true
   end
 
-  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "schedule", null: false
-    t.string "command", limit: 2048
-    t.string "class_name"
-    t.text "arguments"
-    t.string "queue_name"
-    t.integer "priority", default: 0
-    t.boolean "static", default: true, null: false
-    t.text "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index [ "key" ], name: "index_solid_queue_recurring_tasks_on_key", unique: true
-    t.index [ "static" ], name: "index_solid_queue_recurring_tasks_on_static"
+  create_table 'solid_queue_recurring_tasks', force: :cascade do |t|
+    t.string 'key', null: false
+    t.string 'schedule', null: false
+    t.string 'command', limit: 2048
+    t.string 'class_name'
+    t.text 'arguments'
+    t.string 'queue_name'
+    t.integer 'priority', default: 0
+    t.boolean 'static', default: true, null: false
+    t.text 'description'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['key'], name: 'index_solid_queue_recurring_tasks_on_key', unique: true
+    t.index ['static'], name: 'index_solid_queue_recurring_tasks_on_static'
   end
 
-  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
-    t.datetime "scheduled_at", null: false
-    t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
-    t.index [ "scheduled_at", "priority", "job_id" ], name: "index_solid_queue_dispatch_all"
+  create_table 'solid_queue_scheduled_executions', force: :cascade do |t|
+    t.bigint 'job_id', null: false
+    t.string 'queue_name', null: false
+    t.integer 'priority', default: 0, null: false
+    t.datetime 'scheduled_at', null: false
+    t.datetime 'created_at', null: false
+    t.index ['job_id'], name: 'index_solid_queue_scheduled_executions_on_job_id', unique: true
+    t.index %w[scheduled_at priority job_id], name: 'index_solid_queue_dispatch_all'
   end
 
-  create_table "solid_queue_semaphores", force: :cascade do |t|
-    t.string "key", null: false
-    t.integer "value", default: 1, null: false
-    t.datetime "expires_at", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index [ "expires_at" ], name: "index_solid_queue_semaphores_on_expires_at"
-    t.index [ "key", "value" ], name: "index_solid_queue_semaphores_on_key_and_value"
-    t.index [ "key" ], name: "index_solid_queue_semaphores_on_key", unique: true
+  create_table 'solid_queue_semaphores', force: :cascade do |t|
+    t.string 'key', null: false
+    t.integer 'value', default: 1, null: false
+    t.datetime 'expires_at', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['expires_at'], name: 'index_solid_queue_semaphores_on_expires_at'
+    t.index %w[key value], name: 'index_solid_queue_semaphores_on_key_and_value'
+    t.index ['key'], name: 'index_solid_queue_semaphores_on_key', unique: true
   end
 
-  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key 'solid_queue_blocked_executions', 'solid_queue_jobs', column: 'job_id', on_delete: :cascade
+  add_foreign_key 'solid_queue_claimed_executions', 'solid_queue_jobs', column: 'job_id', on_delete: :cascade
+  add_foreign_key 'solid_queue_failed_executions', 'solid_queue_jobs', column: 'job_id', on_delete: :cascade
+  add_foreign_key 'solid_queue_ready_executions', 'solid_queue_jobs', column: 'job_id', on_delete: :cascade
+  add_foreign_key 'solid_queue_recurring_executions', 'solid_queue_jobs', column: 'job_id', on_delete: :cascade
+  add_foreign_key 'solid_queue_scheduled_executions', 'solid_queue_jobs', column: 'job_id', on_delete: :cascade
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,7 @@
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 
-puts "Cleaning database..."
+Rails.logger.debug 'Cleaning database...'
 Setting.destroy_all
 Example.destroy_all
 Meaning.destroy_all
@@ -10,24 +10,24 @@ Word.destroy_all
 Wordbook.destroy_all
 User.destroy_all
 
-puts "Creating test users..."
+Rails.logger.debug 'Creating test users...'
 user1 = User.create!(
-  email: "test@example.com",
-  name: "Test User",
-  provider: "google",
-  provider_uid: "test123",
-  avatar_url: "https://example.com/avatar.jpg"
+  email: 'test@example.com',
+  name: 'Test User',
+  provider: 'google',
+  provider_uid: 'test123',
+  avatar_url: 'https://example.com/avatar.jpg'
 )
 
 user2 = User.create!(
-  email: "demo@example.com",
-  name: "Demo User",
-  provider: "google",
-  provider_uid: "demo456",
-  avatar_url: "https://example.com/demo.jpg"
+  email: 'demo@example.com',
+  name: 'Demo User',
+  provider: 'google',
+  provider_uid: 'demo456',
+  avatar_url: 'https://example.com/demo.jpg'
 )
 
-puts "Creating settings..."
+Rails.logger.debug 'Creating settings...'
 Setting.create!(
   user: user1,
   hard_interval: 1.day,
@@ -42,102 +42,102 @@ Setting.create!(
   easy_interval: 10.days
 )
 
-puts "Creating wordbooks..."
+Rails.logger.debug 'Creating wordbooks...'
 wordbook1 = Wordbook.create!(
   user: user1,
-  title: "英単語基礎"
+  title: '英単語基礎'
 )
 
 wordbook2 = Wordbook.create!(
   user: user1,
-  title: "ビジネス英語"
+  title: 'ビジネス英語'
 )
 
-wordbook3 = Wordbook.create!(
+Wordbook.create!(
   user: user2,
-  title: "TOEIC対策"
+  title: 'TOEIC対策'
 )
 
-puts "Creating words..."
+Rails.logger.debug 'Creating words...'
 word1 = Word.create!(
   wordbook: wordbook1,
-  spelling: "apple",
-  status: "hard",
-  next_review_at: Time.current + 1.day
+  spelling: 'apple',
+  status: 'hard',
+  next_review_at: 1.day.from_now
 )
 
 word2 = Word.create!(
   wordbook: wordbook1,
-  spelling: "book",
-  status: "uncertain",
-  next_review_at: Time.current + 3.days
+  spelling: 'book',
+  status: 'uncertain',
+  next_review_at: 3.days.from_now
 )
 
 word3 = Word.create!(
   wordbook: wordbook2,
-  spelling: "negotiate",
-  status: "not_studied",
-  next_review_at: Time.current + 2.days
+  spelling: 'negotiate',
+  status: 'not_studied',
+  next_review_at: 2.days.from_now
 )
 
-puts "Creating meanings..."
+Rails.logger.debug 'Creating meanings...'
 Meaning.create!(
   word: word1,
-  content: "りんご",
+  content: 'りんご',
   display_order: 1
 )
 
 Meaning.create!(
   word: word2,
-  content: "本",
+  content: '本',
   display_order: 1
 )
 
 Meaning.create!(
   word: word2,
-  content: "予約する",
+  content: '予約する',
   display_order: 2
 )
 
 Meaning.create!(
   word: word3,
-  content: "交渉する",
+  content: '交渉する',
   display_order: 1
 )
 
-puts "Creating examples..."
+Rails.logger.debug 'Creating examples...'
 Example.create!(
   word: word1,
-  sentence: "I like apples.",
-  translation: "私はりんごが好きです。",
+  sentence: 'I like apples.',
+  translation: '私はりんごが好きです。',
   display_order: 1
 )
 
 Example.create!(
   word: word1,
-  sentence: "This is a red apple.",
-  translation: "これは赤いりんごです。",
+  sentence: 'This is a red apple.',
+  translation: 'これは赤いりんごです。',
   display_order: 2
 )
 
 Example.create!(
   word: word2,
-  sentence: "I read a book every day.",
-  translation: "私は毎日本を読みます。",
+  sentence: 'I read a book every day.',
+  translation: '私は毎日本を読みます。',
   display_order: 1
 )
 
 Example.create!(
   word: word3,
-  sentence: "We need to negotiate the terms.",
-  translation: "私たちは条件を交渉する必要があります。",
+  sentence: 'We need to negotiate the terms.',
+  translation: '私たちは条件を交渉する必要があります。',
   display_order: 1
 )
 
-puts "Seed data created successfully!"
-puts "Users: #{User.count}"
-puts "Settings: #{Setting.count}"
-puts "Wordbooks: #{Wordbook.count}"
-puts "Words: #{Word.count}"
-puts "Meanings: #{Meaning.count}"
-puts "Examples: #{Example.count}"
+Rails.logger.debug 'Seed data created successfully!'
+Rails.logger.debug { "Users: #{User.count}" }
+Rails.logger.debug { "Settings: #{Setting.count}" }
+Rails.logger.debug { "Wordbooks: #{Wordbook.count}" }
+Rails.logger.debug { "Words: #{Word.count}" }
+Rails.logger.debug { "Meanings: #{Meaning.count}" }
+Rails.logger.debug { "Examples: #{Example.count}" }

--- a/docs/rubocop_configuration.md
+++ b/docs/rubocop_configuration.md
@@ -1,0 +1,284 @@
+# RuboCop 設定ガイド
+
+## 背景
+
+本プロジェクトはもともと `rubocop-rails-omakase`（v1.1.0）を RuboCop の設定として使用していた。
+omakase プリセットはフォーマット系の少数の cop のみを有効にし、大半のカテゴリを無効化する設計になっている:
+
+- **Security**: 全 cop 無効
+- **Lint**: 3 cop のみ有効（RedundantStringCoercion, RequireParentheses, UriEscapeUnescape）
+- **Style**: 約12 cop 有効（主にフォーマット系）
+- **Layout**: 約25 cop 有効
+- **Rails**: 2 cop のみ有効（AssertNot, RefuteMethods）
+- **Performance**: 1 cop のみ有効（FlatMap）
+- **Metrics / Naming / Bundler / Gemspec**: 全て無効
+
+これにより、セキュリティやコード正当性に関する静的解析のカバレッジに大きな空白があった。
+
+## 現在の設定
+
+`rubocop-rails-omakase` を標準的な RuboCop gem 群に置き換え、汎用的な設定を構築した。
+
+### 導入 gem
+
+| gem | 用途 |
+| --- | --- |
+| `rubocop` | Ruby の基本的な lint・スタイルチェック |
+| `rubocop-rails` | Rails 固有の cop（ActiveRecord, ルーティング, コントローラーパターン） |
+| `rubocop-performance` | パフォーマンス関連の cop（非効率なパターン、不要なメモリ割り当て） |
+| `rubocop-rspec` | RSpec 固有の cop（テスト構造、命名、ベストプラクティス） |
+
+### .rubocop.yml の設定内容
+
+#### AllCops
+
+```yaml
+AllCops:
+  NewCops: enable          # 新バージョンで追加される cop を自動で有効化
+  SuggestExtensions: false # 拡張機能の提案メッセージを非表示
+  TargetRubyVersion: 3.3   # .ruby-version に合わせる
+  Exclude:
+    - "bin/**/*"           # 自動生成される binstub
+    - "db/schema.rb"       # 自動生成されるスキーマ
+    - "vendor/**/*"        # サードパーティコード
+    - "node_modules/**/*"  # JS 依存（存在する場合）
+```
+
+#### 無効化したカテゴリ
+
+| カテゴリ | 理由 |
+| --- | --- |
+| `Metrics` | メソッド長、クラス長、循環的複雑度などは誤検知が多く主観的。コードレビューで対応するほうが効果的。 |
+| `Naming` | 変数名やメソッド名の規約は主観的で、ドメイン固有の用語と衝突しやすい。 |
+
+#### 無効化した個別 cop
+
+| cop | 理由 |
+| --- | --- |
+| `Style/Documentation` | API-only アプリであり、クラスごとのドキュメントコメントは不要。 |
+| `Style/FrozenStringLiteralComment` | Ruby 3.x では多くの文脈で文字列がデフォルトで frozen になるため、マジックコメントの必要性が低下している。 |
+
+#### RSpec cop（デフォルトを緩和）
+
+RSpec cop のデフォルト閾値は非常に厳しいため、実用的な範囲に緩和した:
+
+| cop | デフォルト | 設定値 | 理由 |
+| --- | --- | --- | --- |
+| `RSpec/MultipleExpectations` | 1 | 10 | リクエストスペックでは1テストに複数のアサーションが自然 |
+| `RSpec/ExampleLength` | 5行 | 15行 | セットアップが多いリクエストスペックにはより多くの行数が必要 |
+| `RSpec/MultipleMemoizedHelpers` | 5 | 10 | 複雑なテストシナリオでは let/let! の定義が増える |
+| `RSpec/NestedGroups` | 3 | 5 | 認証やネストリソースのスペックではより深いコンテキストが必要 |
+| `RSpec/LetSetup` | 有効 | 無効 | `let!` によるセットアップはリクエストスペックで一般的なパターン |
+
+#### マイグレーションの除外
+
+| cop | 理由 |
+| --- | --- |
+| `Rails/BulkChangeTable` | マイグレーションは一度だけ実行されるため、ALTER 文の最適化のためにリファクタリングする価値は低い。 |
+| `Rails/SquishedSQLHeredocs` | マイグレーション内の生 SQL は可読性のために複数行フォーマットを維持するほうが望ましい。 |
+
+## 検出・修正した警告の種類
+
+### Style 系
+
+#### Style/StringLiterals
+
+- **内容**: 文字列補間や特殊文字が不要な場合はシングルクォートを使用する
+- **修正前**: `gem "rails", "~> 8.1.0"`
+- **修正後**: `gem 'rails', '~> 8.1.0'`
+- **影響範囲**: 全 `.rb` ファイル（最も多い修正）
+
+#### Style/SymbolArray
+
+- **内容**: シンボル配列には `%i[]` 記法を使用する
+- **修正前**: `only: [ :show, :update, :destroy ]`
+- **修正後**: `only: %i[show update destroy]`
+
+#### Style/NumericPredicate
+
+- **内容**: 数値比較の代わりに述語メソッドを使用する
+- **修正前**: `value.to_i > 0`
+- **修正後**: `value.to_i.positive?`
+
+#### Style/IfUnlessModifier
+
+- **内容**: 単一行の条件文には修飾子形式を使用する
+- **修正前**:
+
+  ```ruby
+  if includes.any?
+    @word = @wordbook.words.includes(*includes.map(&:to_sym)).find(params[:id])
+  end
+  ```
+
+- **修正後**:
+
+  ```ruby
+  @word = @wordbook.words.includes(*includes.map(&:to_sym)).find(params[:id]) if includes.any?
+  ```
+
+#### Style/GlobalStdStream
+
+- **内容**: 標準ストリームにはグローバル変数を使用する
+- **修正前**: `ActiveSupport::TaggedLogging.logger(STDOUT)`
+- **修正後**: `ActiveSupport::TaggedLogging.logger($stdout)`
+
+### Layout 系
+
+#### Layout/LineLength
+
+- **内容**: 1行は120文字以下にする
+- **対応**: 長い式をローカル変数に切り出す
+- **例**:
+
+  ```ruby
+  # 修正前
+  error: "This email is already registered with #{existing_user.provider}. Please sign in with #{existing_user.provider}."
+
+  # 修正後
+  message = "This email is already registered with #{existing_user.provider}. " \
+            "Please sign in with #{existing_user.provider}."
+  ```
+
+#### Layout/SpaceInsideArrayLiteralBrackets
+
+- **内容**: 配列ブラケット内にスペースを入れない
+- **修正前**: `[ :show, :update, :destroy ]`
+- **修正後**: `[:show, :update, :destroy]`
+
+#### Layout/SpaceInsidePercentLiteralDelimiters
+
+- **内容**: パーセントリテラルのデリミタ内にスペースを入れない
+- **修正前**: `%i[ windows jruby ]`
+- **修正後**: `%i[windows jruby]`
+
+#### Layout/EmptyLineAfterGuardClause
+
+- **内容**: ガード節の後に空行を入れて可読性を向上させる
+- **修正前**:
+
+  ```ruby
+  return [] if params[:include].blank?
+  params[:include].split(',')...
+  ```
+
+- **修正後**:
+
+  ```ruby
+  return [] if params[:include].blank?
+
+  params[:include].split(',')...
+  ```
+
+### Rails 系
+
+#### Rails/StrongParametersExpect
+
+- **内容**: `params.require.permit` の代わりに `params.expect` を使用する（Rails 8.x の新 API）
+- **修正前**: `params.require(:word).permit(:spelling, :status)`
+- **修正後**: `params.expect(word: %i[spelling status])`
+- **補足**: `params.expect` は Rails 8 で導入された Strong Parameters の新しい API
+
+#### Rails/HttpStatusNameConsistency
+
+- **内容**: 非推奨の `:unprocessable_entity` の代わりに `:unprocessable_content`（RFC 9110 準拠の命名）を使用する
+- **修正前**: `status: :unprocessable_entity`
+- **修正後**: `status: :unprocessable_content`
+
+#### Rails/HasManyOrHasOneDependent
+
+- **内容**: アソシエーションに `:dependent` オプションを必ず指定する
+- **対応**: `has_one :first_meaning` に `dependent: nil` を追加（読み取り専用の派生アソシエーション）
+
+#### Rails/InverseOf
+
+- **内容**: カスタムクラス名やスコープを持つアソシエーションに `:inverse_of` を指定する
+- **対応**: `has_one :first_meaning` に `inverse_of: false` を追加（対称的な逆アソシエーションを持たないスコープ付きアソシエーション）
+
+#### Rails/SkipsModelValidations
+
+- **内容**: ActiveRecord のバリデーションをスキップするメソッド（`update_all`, `update_column` 等）に対する警告
+- **対応**: インライン無効化コメントを追加。ゲスト→Google アカウント移行時のパフォーマンスのため、`update_all`（一括所有権移転）を意図的に使用している。
+
+#### Rails/Pluck
+
+- **内容**: 単一属性の抽出には `map` の代わりに `pluck` を使用する
+- **修正前**: `body['meanings'].map { |m| m['content'] }`
+- **修正後**: `body['meanings'].pluck('content')`
+
+### Lint 系
+
+#### Lint/UselessConstantScoping
+
+- **内容**: `private` キーワードの後に定義された定数は、実際にはパブリックにアクセス可能（Ruby は定数のスコープをアクセス修飾子で制御しない）
+- **修正前**:
+
+  ```ruby
+  private
+  ALLOWED_INCLUDES = %w[meanings examples].freeze
+  ```
+
+- **修正後**:
+
+  ```ruby
+  ALLOWED_INCLUDES = %w[meanings examples].freeze
+  private
+  ```
+
+### RSpec 系
+
+#### RSpec/NamedSubject
+
+- **内容**: テストサブジェクトを明示的に参照する場合は名前を付ける
+- **修正前**: `expect(subject).to define_enum_for(:provider)...`
+- **修正後**:
+
+  ```ruby
+  subject(:user) { build(:user) }
+  expect(user).to define_enum_for(:provider)...
+  ```
+
+## 今後の検討事項
+
+### カテゴリごと無効化した cop について
+
+`Metrics` と `Naming` カテゴリは全体を無効化している。将来的に特定の cop を有効にしたい場合は以下を検討:
+
+- `Metrics/MethodLength`（Max: 20-30）— 長すぎるメソッドを検出
+- `Metrics/AbcSize`（Max: 30-40）— 複雑すぎるメソッドを検出
+- `Naming/PredicateName` — boolean メソッドに `?` サフィックスを強制
+
+### 新しい cop の追加について
+
+`NewCops: enable` を設定しているため、RuboCop のアップデートで追加される新しい cop は自動的に有効化される。新しい cop で問題が発生した場合:
+
+1. **特定の行のみ無効化**: `# rubocop:disable CopName`
+2. **プロジェクト全体で無効化**（`.rubocop.yml` に追加）:
+
+   ```yaml
+   CopName:
+     Enabled: false
+   ```
+
+### RuboCop の実行方法
+
+```bash
+# 全ファイルをチェック
+bundle exec rubocop
+
+# 安全な自動修正を実行
+bundle exec rubocop -a
+
+# 安全でない修正も含めて自動修正を実行
+bundle exec rubocop -A
+
+# 特定のファイルをチェック
+bundle exec rubocop app/controllers/api/v1/words_controller.rb
+
+# 段階的な導入のための todo ファイルを生成
+bundle exec rubocop --auto-gen-config --auto-gen-only-exclude
+```
+
+### CI 連携
+
+RuboCop は `.github/workflows/ci.yml` で `bin/rubocop -f github` として CI 上で実行される。PR の diff に直接アノテーションが表示される。

--- a/spec/factories/examples.rb
+++ b/spec/factories/examples.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :example do
     association :word
-    sentence { "Hello, world!" }
-    translation { "こんにちは、世界！" }
+    sentence { 'Hello, world!' }
+    translation { 'こんにちは、世界！' }
     sequence(:display_order) { |n| n }
   end
 end

--- a/spec/factories/meanings.rb
+++ b/spec/factories/meanings.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :meaning do
     association :word
-    content { "こんにちは" }
+    content { 'こんにちは' }
     sequence(:display_order) { |n| n }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :user do
     sequence(:provider_uid) { |n| "uid_#{n}" }
-    provider { "google" }
+    provider { 'google' }
     sequence(:email) { |n| "user#{n}@example.com" }
-    name { "Test User" }
+    name { 'Test User' }
 
     trait :guest do
-      provider { "guest" }
+      provider { 'guest' }
       provider_uid { nil }
       email { nil }
       name { nil }

--- a/spec/factories/wordbooks.rb
+++ b/spec/factories/wordbooks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :wordbook do
     association :user
-    title { "My Wordbook" }
+    title { 'My Wordbook' }
   end
 end

--- a/spec/factories/words.rb
+++ b/spec/factories/words.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :word do
     association :wordbook
-    spelling { "hello" }
-    status { "not_studied" }
+    spelling { 'hello' }
+    status { 'not_studied' }
   end
 end

--- a/spec/models/example_spec.rb
+++ b/spec/models/example_spec.rb
@@ -1,19 +1,19 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe Example, type: :model do
-  describe "associations" do
+  describe 'associations' do
     it { is_expected.to belong_to(:word) }
   end
 
-  describe "validations" do
+  describe 'validations' do
     it { is_expected.to validate_presence_of(:sentence) }
     it { is_expected.to validate_presence_of(:translation) }
     it { is_expected.to validate_presence_of(:display_order) }
     it { is_expected.to validate_numericality_of(:display_order).only_integer.is_greater_than(0) }
   end
 
-  describe "factory" do
-    it "creates a valid example" do
+  describe 'factory' do
+    it 'creates a valid example' do
       expect(build(:example)).to be_valid
     end
   end

--- a/spec/models/meaning_spec.rb
+++ b/spec/models/meaning_spec.rb
@@ -1,18 +1,18 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe Meaning, type: :model do
-  describe "associations" do
+  describe 'associations' do
     it { is_expected.to belong_to(:word) }
   end
 
-  describe "validations" do
+  describe 'validations' do
     it { is_expected.to validate_presence_of(:content) }
     it { is_expected.to validate_presence_of(:display_order) }
     it { is_expected.to validate_numericality_of(:display_order).only_integer.is_greater_than(0) }
   end
 
-  describe "factory" do
-    it "creates a valid meaning" do
+  describe 'factory' do
+    it 'creates a valid meaning' do
       expect(build(:meaning)).to be_valid
     end
   end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -1,33 +1,33 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe Setting, type: :model do
-  describe "associations" do
+  describe 'associations' do
     it { is_expected.to belong_to(:user) }
   end
 
-  describe "validations" do
+  describe 'validations' do
     it { is_expected.to validate_presence_of(:hard_interval) }
     it { is_expected.to validate_presence_of(:uncertain_interval) }
     it { is_expected.to validate_presence_of(:easy_interval) }
   end
 
-  describe "custom validation: intervals_must_be_positive" do
+  describe 'custom validation: intervals_must_be_positive' do
     let(:user) { create(:user) }
 
-    it "is valid with positive durations" do
+    it 'is valid with positive durations' do
       setting = build(:setting, user: user)
       expect(setting).to be_valid
     end
 
-    it "is invalid with zero duration" do
+    it 'is invalid with zero duration' do
       setting = build(:setting, user: user, hard_interval: 0.days)
       expect(setting).not_to be_valid
-      expect(setting.errors[:hard_interval]).to include("must be a positive interval")
+      expect(setting.errors[:hard_interval]).to include('must be a positive interval')
     end
   end
 
-  describe "factory" do
-    it "creates a valid setting" do
+  describe 'factory' do
+    it 'creates a valid setting' do
       expect(build(:setting)).to be_valid
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,64 +1,69 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe "associations" do
+  describe 'associations' do
     it { is_expected.to have_many(:wordbooks).dependent(:destroy) }
     it { is_expected.to have_one(:setting).dependent(:destroy) }
   end
 
-  describe "validations" do
+  describe 'validations' do
     subject { build(:user) }
 
     it { is_expected.to validate_presence_of(:provider) }
     it { is_expected.to validate_uniqueness_of(:email).allow_nil }
 
-    context "when provider is google" do
-      subject { build(:user, provider: "google") }
+    context 'when provider is google' do
+      subject { build(:user, provider: 'google') }
 
       it { is_expected.to validate_presence_of(:provider_uid) }
       it { is_expected.to validate_uniqueness_of(:provider_uid).scoped_to(:provider) }
     end
 
-    context "when provider is guest" do
-      it "does not require provider_uid" do
+    context 'when provider is guest' do
+      it 'does not require provider_uid' do
         user = build(:user, :guest, provider_uid: nil)
         expect(user).to be_valid
       end
     end
   end
 
-  describe "enum" do
-    it { is_expected.to define_enum_for(:provider).with_values(google: "google", guest: "guest").backed_by_column_of_type(:string) }
+  describe 'enum' do
+    subject(:user) { build(:user) }
+
+    it {
+      expect(user).to define_enum_for(:provider).with_values(google: 'google',
+                                                             guest: 'guest').backed_by_column_of_type(:string)
+    }
   end
 
-  describe "guest user validations" do
-    context "when provider is guest" do
-      it "requires guest_expires_at" do
+  describe 'guest user validations' do
+    context 'when provider is guest' do
+      it 'requires guest_expires_at' do
         user = build(:user, :guest, guest_expires_at: nil)
         expect(user).not_to be_valid
         expect(user.errors[:guest_expires_at]).to include("can't be blank")
       end
 
-      it "is valid with guest_expires_at set" do
+      it 'is valid with guest_expires_at set' do
         user = build(:user, :guest)
         expect(user).to be_valid
       end
     end
 
-    context "when provider is google" do
-      it "does not require guest_expires_at" do
+    context 'when provider is google' do
+      it 'does not require guest_expires_at' do
         user = build(:user, guest_expires_at: nil)
         expect(user).to be_valid
       end
     end
   end
 
-  describe "factory" do
-    it "creates a valid google user" do
+  describe 'factory' do
+    it 'creates a valid google user' do
       expect(build(:user)).to be_valid
     end
 
-    it "creates a valid guest user" do
+    it 'creates a valid guest user' do
       expect(build(:user, :guest)).to be_valid
     end
   end

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -1,71 +1,73 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe Word, type: :model do
-  describe "associations" do
+  describe 'associations' do
     it { is_expected.to belong_to(:wordbook) }
     it { is_expected.to have_many(:meanings).dependent(:destroy) }
     it { is_expected.to have_many(:examples).dependent(:destroy) }
-    it { is_expected.to have_one(:first_meaning).class_name("Meaning") }
+    it { is_expected.to have_one(:first_meaning).class_name('Meaning') }
   end
 
-  describe "validations" do
+  describe 'validations' do
     it { is_expected.to validate_presence_of(:spelling) }
     it { is_expected.to validate_presence_of(:status) }
   end
 
-  describe "enum" do
+  describe 'enum' do
+    subject(:word) { build(:word) }
+
     it do
-      is_expected.to define_enum_for(:status)
-        .with_values(not_studied: "not_studied", hard: "hard", uncertain: "uncertain", easy: "easy")
+      expect(word).to define_enum_for(:status)
+        .with_values(not_studied: 'not_studied', hard: 'hard', uncertain: 'uncertain', easy: 'easy')
         .backed_by_column_of_type(:string)
     end
   end
 
-  describe "scopes" do
-    describe ".reviewable" do
+  describe 'scopes' do
+    describe '.reviewable' do
       let(:wordbook) { create(:wordbook) }
 
-      it "includes words with next_review_at as nil" do
+      it 'includes words with next_review_at as nil' do
         word = create(:word, wordbook: wordbook, next_review_at: nil)
-        expect(Word.reviewable).to include(word)
+        expect(described_class.reviewable).to include(word)
       end
 
-      it "includes words with next_review_at in the past" do
+      it 'includes words with next_review_at in the past' do
         word = create(:word, wordbook: wordbook, next_review_at: 1.day.ago)
-        expect(Word.reviewable).to include(word)
+        expect(described_class.reviewable).to include(word)
       end
 
-      it "excludes words with next_review_at in the future" do
+      it 'excludes words with next_review_at in the future' do
         word = create(:word, wordbook: wordbook, next_review_at: 1.day.from_now)
-        expect(Word.reviewable).not_to include(word)
+        expect(described_class.reviewable).not_to include(word)
       end
     end
   end
 
-  describe "factory" do
-    it "creates a valid word" do
+  describe 'factory' do
+    it 'creates a valid word' do
       expect(build(:word)).to be_valid
     end
   end
 
-  describe "status transitions" do
+  describe 'status transitions' do
     let(:word) { create(:word) }
 
-    it "defaults to not_studied" do
+    it 'defaults to not_studied' do
       expect(word).to be_not_studied
     end
 
-    it "can be changed to hard" do
+    it 'can be changed to hard' do
       word.hard!
       expect(word).to be_hard
     end
 
-    it "can be changed to uncertain" do
+    it 'can be changed to uncertain' do
       word.uncertain!
       expect(word).to be_uncertain
     end
 
-    it "can be changed to easy" do
+    it 'can be changed to easy' do
       word.easy!
       expect(word).to be_easy
     end

--- a/spec/models/wordbook_spec.rb
+++ b/spec/models/wordbook_spec.rb
@@ -1,17 +1,17 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe Wordbook, type: :model do
-  describe "associations" do
+  describe 'associations' do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to have_many(:words).dependent(:destroy) }
   end
 
-  describe "validations" do
+  describe 'validations' do
     it { is_expected.to validate_presence_of(:title) }
   end
 
-  describe "factory" do
-    it "creates a valid wordbook" do
+  describe 'factory' do
+    it 'creates a valid wordbook' do
       expect(build(:wordbook)).to be_valid
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 # Uncomment the line below in case you have `--require rails_helper` in the `.rspec` file
 # that will avoid rails generators crashing because migrations haven't been run yet
 # return unless Rails.env.test?

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -1,146 +1,146 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "Api::V1::Auth", type: :request do
-  describe "POST /api/v1/auth/guest" do
-    it "creates a guest user and returns 201 with user and JWT token" do
-      expect {
-        post "/api/v1/auth/guest"
-      }.to change(User, :count).by(1)
+RSpec.describe 'Api::V1::Auth', type: :request do
+  describe 'POST /api/v1/auth/guest' do
+    it 'creates a guest user and returns 201 with user and JWT token' do
+      expect do
+        post '/api/v1/auth/guest'
+      end.to change(User, :count).by(1)
 
       expect(response).to have_http_status(:created)
 
       body = response.parsed_body
-      expect(body["user"]).to have_key("guest_expires_at")
-      expect(body["user"].keys).to match_array([ "guest_expires_at" ])
-      expect(body["token"]).to be_present
+      expect(body['user']).to have_key('guest_expires_at')
+      expect(body['user'].keys).to contain_exactly('guest_expires_at')
+      expect(body['token']).to be_present
     end
 
-    it "sets guest_expires_at to approximately 7 days from now" do
-      post "/api/v1/auth/guest"
+    it 'sets guest_expires_at to approximately 7 days from now' do
+      post '/api/v1/auth/guest'
 
       user = User.last
       expect(user.guest_expires_at).to be_within(1.second).of(7.days.from_now)
     end
 
-    it "returns a JWT token containing the user_id" do
-      post "/api/v1/auth/guest"
+    it 'returns a JWT token containing the user_id' do
+      post '/api/v1/auth/guest'
 
       body = response.parsed_body
-      token = body["token"]
+      token = body['token']
       user = User.last
 
-      decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: "HS256")
-      expect(decoded.first["sub"]).to eq(user.id)
+      decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: 'HS256')
+      expect(decoded.first['sub']).to eq(user.id)
     end
 
-    it "returns a JWT token that expires at guest_expires_at" do
-      post "/api/v1/auth/guest"
+    it 'returns a JWT token that expires at guest_expires_at' do
+      post '/api/v1/auth/guest'
 
       body = response.parsed_body
-      token = body["token"]
+      token = body['token']
       user = User.last
 
-      decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: "HS256")
-      expect(decoded.first["exp"]).to eq(user.guest_expires_at.to_i)
+      decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: 'HS256')
+      expect(decoded.first['exp']).to eq(user.guest_expires_at.to_i)
     end
   end
 
-  describe "POST /api/v1/auth/google" do
+  describe 'POST /api/v1/auth/google' do
     let(:google_payload) do
       {
-        "sub" => "google_uid_123",
-        "email" => "test@example.com",
-        "name" => "Test User",
-        "picture" => "https://example.com/avatar.jpg"
+        'sub' => 'google_uid_123',
+        'email' => 'test@example.com',
+        'name' => 'Test User',
+        'picture' => 'https://example.com/avatar.jpg'
       }
     end
 
-    context "when Authorization header is missing" do
-      it "returns bad_request" do
-        post "/api/v1/auth/google"
+    context 'when Authorization header is missing' do
+      it 'returns bad_request' do
+        post '/api/v1/auth/google'
 
         expect(response).to have_http_status(:bad_request)
-        expect(response.parsed_body["error"]).to eq("Authorization header missing")
+        expect(response.parsed_body['error']).to eq('Authorization header missing')
       end
     end
 
-    context "when token is invalid" do
+    context 'when token is invalid' do
       before do
         allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_raise(
-          Google::Auth::IDTokens::VerificationError.new("Invalid token")
+          Google::Auth::IDTokens::VerificationError.new('Invalid token')
         )
       end
 
-      it "returns unauthorized" do
-        post "/api/v1/auth/google", headers: { "Authorization" => "Bearer invalid_token" }
+      it 'returns unauthorized' do
+        post '/api/v1/auth/google', headers: { 'Authorization' => 'Bearer invalid_token' }
 
         expect(response).to have_http_status(:unauthorized)
-        expect(response.parsed_body["error"]).to eq("Invalid ID token")
+        expect(response.parsed_body['error']).to eq('Invalid ID token')
       end
     end
 
-    context "when token is valid and user is new" do
+    context 'when token is valid and user is new' do
       before do
         allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return(google_payload)
       end
 
-      it "creates a new user and returns ok with JWT token" do
-        expect {
-          post "/api/v1/auth/google", headers: { "Authorization" => "Bearer valid_token" }
-        }.to change(User, :count).by(1)
+      it 'creates a new user and returns ok with JWT token' do
+        expect do
+          post '/api/v1/auth/google', headers: { 'Authorization' => 'Bearer valid_token' }
+        end.to change(User, :count).by(1)
 
         expect(response).to have_http_status(:ok)
 
         body = response.parsed_body
-        user_json = body["user"]
-        expect(user_json["email"]).to eq("test@example.com")
-        expect(user_json["name"]).to eq("Test User")
-        expect(user_json["avatar_url"]).to eq("https://example.com/avatar.jpg")
-        expect(user_json.keys).to match_array([ "email", "name", "avatar_url" ])
+        user_json = body['user']
+        expect(user_json['email']).to eq('test@example.com')
+        expect(user_json['name']).to eq('Test User')
+        expect(user_json['avatar_url']).to eq('https://example.com/avatar.jpg')
+        expect(user_json.keys).to match_array(%w[email name avatar_url])
 
-        expect(body["token"]).to be_present
-        decoded = JWT.decode(body["token"], Rails.application.secret_key_base, true, algorithm: "HS256")
-        expect(decoded.first["sub"]).to eq(User.last.id)
+        expect(body['token']).to be_present
+        decoded = JWT.decode(body['token'], Rails.application.secret_key_base, true, algorithm: 'HS256')
+        expect(decoded.first['sub']).to eq(User.last.id)
       end
     end
 
-    context "when token is valid and user already exists" do
+    context 'when token is valid and user already exists' do
       before do
         allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return(google_payload)
-        create(:user, provider: "google", provider_uid: "google_uid_123", email: "test@example.com")
+        create(:user, provider: 'google', provider_uid: 'google_uid_123', email: 'test@example.com')
       end
 
-      it "returns existing user without creating a new one" do
-        expect {
-          post "/api/v1/auth/google", headers: { "Authorization" => "Bearer valid_token" }
-        }.not_to change(User, :count)
+      it 'returns existing user without creating a new one' do
+        expect do
+          post '/api/v1/auth/google', headers: { 'Authorization' => 'Bearer valid_token' }
+        end.not_to change(User, :count)
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body["token"]).to be_present
+        expect(response.parsed_body['token']).to be_present
       end
     end
 
-    context "when email is already registered with a different provider" do
+    context 'when email is already registered with a different provider' do
       before do
         allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return(google_payload)
-        create(:user, :guest, email: "test@example.com")
+        create(:user, :guest, email: 'test@example.com')
       end
 
-      it "returns conflict" do
-        post "/api/v1/auth/google", headers: { "Authorization" => "Bearer valid_token" }
+      it 'returns conflict' do
+        post '/api/v1/auth/google', headers: { 'Authorization' => 'Bearer valid_token' }
 
         expect(response).to have_http_status(:conflict)
-        expect(response.parsed_body["error"]).to include("already registered")
+        expect(response.parsed_body['error']).to include('already registered')
       end
     end
 
-    context "with guest_token (guest migration)" do
+    context 'with guest_token (guest migration)' do
       let(:guest_user) { create(:user, :guest) }
       let(:guest_token) do
         JWT.encode(
           { sub: guest_user.id, exp: guest_user.guest_expires_at.to_i, iat: Time.current.to_i },
           Rails.application.secret_key_base,
-          "HS256"
+          'HS256'
         )
       end
 
@@ -148,152 +148,154 @@ RSpec.describe "Api::V1::Auth", type: :request do
         allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return(google_payload)
       end
 
-      context "when Google account does not exist (in-place conversion)" do
-        let!(:wordbook) { create(:wordbook, user: guest_user, title: "Guest Wordbook") }
-        let!(:word) { create(:word, wordbook: wordbook, spelling: "apple") }
-        let!(:meaning) { create(:meaning, word: word, content: "りんご") }
-        let!(:example) { create(:example, word: word, sentence: "I like apples.", translation: "りんごが好きです。") }
+      context 'when Google account does not exist (in-place conversion)' do
+        let!(:wordbook) { create(:wordbook, user: guest_user, title: 'Guest Wordbook') }
+        let!(:word) { create(:word, wordbook: wordbook, spelling: 'apple') }
+        let!(:meaning) { create(:meaning, word: word, content: 'りんご') }
+        let!(:example) { create(:example, word: word, sentence: 'I like apples.', translation: 'りんごが好きです。') }
         let!(:setting) { create(:setting, user: guest_user) }
 
-        it "converts guest user to Google user and returns ok" do
-          expect {
-            post "/api/v1/auth/google",
+        it 'converts guest user to Google user and returns ok' do
+          expect do
+            post '/api/v1/auth/google',
                  params: { guest_token: guest_token },
-                 headers: { "Authorization" => "Bearer valid_token" }
-          }.not_to change(User, :count)
+                 headers: { 'Authorization' => 'Bearer valid_token' }
+          end.not_to change(User, :count)
 
           expect(response).to have_http_status(:ok)
 
           body = response.parsed_body
-          expect(body["user"]["email"]).to eq("test@example.com")
-          expect(body["user"]["name"]).to eq("Test User")
-          expect(body["user"]["avatar_url"]).to eq("https://example.com/avatar.jpg")
-          expect(body["token"]).to be_present
+          expect(body['user']['email']).to eq('test@example.com')
+          expect(body['user']['name']).to eq('Test User')
+          expect(body['user']['avatar_url']).to eq('https://example.com/avatar.jpg')
+          expect(body['token']).to be_present
         end
 
-        it "updates guest user attributes to Google user" do
-          post "/api/v1/auth/google",
+        it 'updates guest user attributes to Google user' do
+          post '/api/v1/auth/google',
                params: { guest_token: guest_token },
-               headers: { "Authorization" => "Bearer valid_token" }
+               headers: { 'Authorization' => 'Bearer valid_token' }
 
           guest_user.reload
-          expect(guest_user.provider).to eq("google")
-          expect(guest_user.provider_uid).to eq("google_uid_123")
-          expect(guest_user.email).to eq("test@example.com")
+          expect(guest_user.provider).to eq('google')
+          expect(guest_user.provider_uid).to eq('google_uid_123')
+          expect(guest_user.email).to eq('test@example.com')
           expect(guest_user.guest_expires_at).to be_nil
         end
 
-        it "preserves all guest data (wordbooks, words, meanings, examples, settings)" do
-          post "/api/v1/auth/google",
+        it 'preserves all guest data (wordbooks, words, meanings, examples, settings)' do
+          post '/api/v1/auth/google',
                params: { guest_token: guest_token },
-               headers: { "Authorization" => "Bearer valid_token" }
+               headers: { 'Authorization' => 'Bearer valid_token' }
 
           guest_user.reload
           expect(guest_user.wordbooks.count).to eq(1)
-          expect(guest_user.wordbooks.first.title).to eq("Guest Wordbook")
+          expect(guest_user.wordbooks.first.title).to eq('Guest Wordbook')
           expect(guest_user.wordbooks.first.words.count).to eq(1)
           expect(guest_user.wordbooks.first.words.first.meanings.count).to eq(1)
           expect(guest_user.wordbooks.first.words.first.examples.count).to eq(1)
           expect(guest_user.setting).to be_present
         end
 
-        it "returns a JWT token for the converted user" do
-          post "/api/v1/auth/google",
+        it 'returns a JWT token for the converted user' do
+          post '/api/v1/auth/google',
                params: { guest_token: guest_token },
-               headers: { "Authorization" => "Bearer valid_token" }
+               headers: { 'Authorization' => 'Bearer valid_token' }
 
-          token = response.parsed_body["token"]
-          decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: "HS256")
-          expect(decoded.first["sub"]).to eq(guest_user.id)
+          token = response.parsed_body['token']
+          decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: 'HS256')
+          expect(decoded.first['sub']).to eq(guest_user.id)
         end
       end
 
-      context "when Google account already exists (merge)" do
-        let!(:google_user) { create(:user, provider: "google", provider_uid: "google_uid_123", email: "test@example.com") }
-        let!(:guest_wordbook) { create(:wordbook, user: guest_user, title: "Guest Wordbook") }
-        let!(:guest_word) { create(:word, wordbook: guest_wordbook, spelling: "banana") }
-        let!(:guest_meaning) { create(:meaning, word: guest_word, content: "バナナ") }
+      context 'when Google account already exists (merge)' do
+        let!(:google_user) do
+          create(:user, provider: 'google', provider_uid: 'google_uid_123', email: 'test@example.com')
+        end
+        let!(:guest_wordbook) { create(:wordbook, user: guest_user, title: 'Guest Wordbook') }
+        let!(:guest_word) { create(:word, wordbook: guest_wordbook, spelling: 'banana') }
+        let!(:guest_meaning) { create(:meaning, word: guest_word, content: 'バナナ') }
         let!(:guest_setting) { create(:setting, user: guest_user) }
 
-        it "merges guest data into existing Google user and deletes guest" do
-          expect {
-            post "/api/v1/auth/google",
+        it 'merges guest data into existing Google user and deletes guest' do
+          expect do
+            post '/api/v1/auth/google',
                  params: { guest_token: guest_token },
-                 headers: { "Authorization" => "Bearer valid_token" }
-          }.to change(User, :count).by(-1)
+                 headers: { 'Authorization' => 'Bearer valid_token' }
+          end.to change(User, :count).by(-1)
 
           expect(response).to have_http_status(:ok)
           expect { guest_user.reload }.to raise_error(ActiveRecord::RecordNotFound)
         end
 
-        it "transfers wordbooks to the Google user" do
-          post "/api/v1/auth/google",
+        it 'transfers wordbooks to the Google user' do
+          post '/api/v1/auth/google',
                params: { guest_token: guest_token },
-               headers: { "Authorization" => "Bearer valid_token" }
+               headers: { 'Authorization' => 'Bearer valid_token' }
 
           expect(google_user.wordbooks.count).to eq(1)
-          expect(google_user.wordbooks.first.title).to eq("Guest Wordbook")
+          expect(google_user.wordbooks.first.title).to eq('Guest Wordbook')
           expect(google_user.wordbooks.first.words.first.meanings.count).to eq(1)
         end
 
-        it "transfers setting when Google user has no setting" do
-          post "/api/v1/auth/google",
+        it 'transfers setting when Google user has no setting' do
+          post '/api/v1/auth/google',
                params: { guest_token: guest_token },
-               headers: { "Authorization" => "Bearer valid_token" }
+               headers: { 'Authorization' => 'Bearer valid_token' }
 
           expect(google_user.reload.setting).to be_present
         end
 
-        it "keeps Google user setting when both have settings" do
+        it 'keeps Google user setting when both have settings' do
           google_setting = create(:setting, user: google_user, hard_interval: 2.days)
 
-          post "/api/v1/auth/google",
+          post '/api/v1/auth/google',
                params: { guest_token: guest_token },
-               headers: { "Authorization" => "Bearer valid_token" }
+               headers: { 'Authorization' => 'Bearer valid_token' }
 
           google_user.reload
           expect(google_user.setting.id).to eq(google_setting.id)
         end
 
-        it "returns a JWT token for the Google user" do
-          post "/api/v1/auth/google",
+        it 'returns a JWT token for the Google user' do
+          post '/api/v1/auth/google',
                params: { guest_token: guest_token },
-               headers: { "Authorization" => "Bearer valid_token" }
+               headers: { 'Authorization' => 'Bearer valid_token' }
 
-          token = response.parsed_body["token"]
-          decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: "HS256")
-          expect(decoded.first["sub"]).to eq(google_user.id)
+          token = response.parsed_body['token']
+          decoded = JWT.decode(token, Rails.application.secret_key_base, true, algorithm: 'HS256')
+          expect(decoded.first['sub']).to eq(google_user.id)
         end
       end
 
-      context "when guest_token is invalid" do
-        it "returns unauthorized" do
-          post "/api/v1/auth/google",
-               params: { guest_token: "invalid_token" },
-               headers: { "Authorization" => "Bearer valid_token" }
+      context 'when guest_token is invalid' do
+        it 'returns unauthorized' do
+          post '/api/v1/auth/google',
+               params: { guest_token: 'invalid_token' },
+               headers: { 'Authorization' => 'Bearer valid_token' }
 
           expect(response).to have_http_status(:unauthorized)
-          expect(response.parsed_body["error"]).to eq("Invalid guest token")
+          expect(response.parsed_body['error']).to eq('Invalid guest token')
         end
       end
 
-      context "when guest_token belongs to a Google user" do
-        let(:google_user) { create(:user, provider: "google", provider_uid: "other_uid") }
+      context 'when guest_token belongs to a Google user' do
+        let(:google_user) { create(:user, provider: 'google', provider_uid: 'other_uid') }
         let(:non_guest_token) do
           JWT.encode(
             { sub: google_user.id, exp: 30.days.from_now.to_i, iat: Time.current.to_i },
             Rails.application.secret_key_base,
-            "HS256"
+            'HS256'
           )
         end
 
-        it "returns unauthorized" do
-          post "/api/v1/auth/google",
+        it 'returns unauthorized' do
+          post '/api/v1/auth/google',
                params: { guest_token: non_guest_token },
-               headers: { "Authorization" => "Bearer valid_token" }
+               headers: { 'Authorization' => 'Bearer valid_token' }
 
           expect(response).to have_http_status(:unauthorized)
-          expect(response.parsed_body["error"]).to eq("Invalid guest token")
+          expect(response.parsed_body['error']).to eq('Invalid guest token')
         end
       end
     end

--- a/spec/requests/api/v1/examples_spec.rb
+++ b/spec/requests/api/v1/examples_spec.rb
@@ -1,12 +1,12 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "Api::V1::Examples", type: :request do
+RSpec.describe 'Api::V1::Examples', type: :request do
   let(:user) { create(:user) }
   let(:headers) { auth_headers_for(user) }
   let(:wordbook) { create(:wordbook, user: user) }
   let(:word) { create(:word, wordbook: wordbook) }
 
-  describe "GET /api/v1/wordbooks/:wordbook_id/words/:word_id/examples" do
+  describe 'GET /api/v1/wordbooks/:wordbook_id/words/:word_id/examples' do
     it "returns current user's examples" do
       create_list(:example, 2, word: word)
       create(:example) # another user's example
@@ -17,7 +17,7 @@ RSpec.describe "Api::V1::Examples", type: :request do
       expect(response.parsed_body.size).to eq(2)
     end
 
-    it "returns 401 without authentication" do
+    it 'returns 401 without authentication' do
       get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples"
 
       expect(response).to have_http_status(:unauthorized)
@@ -33,14 +33,14 @@ RSpec.describe "Api::V1::Examples", type: :request do
     end
   end
 
-  describe "GET /api/v1/wordbooks/:wordbook_id/words/:word_id/examples/:id" do
-    it "returns the example" do
-      example = create(:example, word: word, sentence: "Good morning")
+  describe 'GET /api/v1/wordbooks/:wordbook_id/words/:word_id/examples/:id' do
+    it 'returns the example' do
+      example = create(:example, word: word, sentence: 'Good morning')
 
       get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples/#{example.id}", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body["sentence"]).to eq("Good morning")
+      expect(response.parsed_body['sentence']).to eq('Good morning')
     end
 
     it "returns not_found for another user's example" do
@@ -54,51 +54,54 @@ RSpec.describe "Api::V1::Examples", type: :request do
     end
   end
 
-  describe "POST /api/v1/wordbooks/:wordbook_id/words/:word_id/examples" do
-    context "with valid params" do
-      it "creates an example" do
+  describe 'POST /api/v1/wordbooks/:wordbook_id/words/:word_id/examples' do
+    context 'with valid params' do
+      it 'creates an example' do
         params = {
           example: {
-            sentence: "See you later",
-            translation: "またね",
+            sentence: 'See you later',
+            translation: 'またね',
             display_order: 1
           }
         }
 
-        expect {
+        expect do
           post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples", params: params, headers: headers
-        }.to change(Example, :count).by(1)
+        end.to change(Example, :count).by(1)
 
         expect(response).to have_http_status(:created)
       end
     end
 
-    context "with invalid params" do
-      it "returns unprocessable_entity" do
-        post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples", params: { example: { sentence: "", translation: "翻訳", display_order: 1 } }, headers: headers
+    context 'with invalid params' do
+      it 'returns unprocessable_entity' do
+        post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples",
+             params: { example: { sentence: '', translation: '翻訳', display_order: 1 } }, headers: headers
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 
-    it "returns not_found when word belongs to another user" do
+    it 'returns not_found when word belongs to another user' do
       other_wordbook = create(:wordbook)
       other_word = create(:word, wordbook: other_wordbook)
 
-      post "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples", params: { example: { sentence: "test", translation: "test", display_order: 1 } }, headers: headers
+      post "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples",
+           params: { example: { sentence: 'test', translation: 'test', display_order: 1 } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "PATCH /api/v1/wordbooks/:wordbook_id/words/:word_id/examples/:id" do
+  describe 'PATCH /api/v1/wordbooks/:wordbook_id/words/:word_id/examples/:id' do
     let(:example_record) { create(:example, word: word) }
 
-    it "updates the example" do
-      patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples/#{example_record.id}", params: { example: { sentence: "Updated sentence" } }, headers: headers
+    it 'updates the example' do
+      patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples/#{example_record.id}",
+            params: { example: { sentence: 'Updated sentence' } }, headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body["sentence"]).to eq("Updated sentence")
+      expect(response.parsed_body['sentence']).to eq('Updated sentence')
     end
 
     it "returns not_found for another user's example" do
@@ -106,19 +109,20 @@ RSpec.describe "Api::V1::Examples", type: :request do
       other_word = create(:word, wordbook: other_wordbook)
       other_example = create(:example, word: other_word)
 
-      patch "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples/#{other_example.id}", params: { example: { sentence: "hacked" } }, headers: headers
+      patch "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples/#{other_example.id}",
+            params: { example: { sentence: 'hacked' } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "DELETE /api/v1/wordbooks/:wordbook_id/words/:word_id/examples/:id" do
-    it "deletes the example" do
+  describe 'DELETE /api/v1/wordbooks/:wordbook_id/words/:word_id/examples/:id' do
+    it 'deletes the example' do
       example_record = create(:example, word: word)
 
-      expect {
+      expect do
         delete "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples/#{example_record.id}", headers: headers
-      }.to change(Example, :count).by(-1)
+      end.to change(Example, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end
@@ -128,7 +132,8 @@ RSpec.describe "Api::V1::Examples", type: :request do
       other_word = create(:word, wordbook: other_wordbook)
       other_example = create(:example, word: other_word)
 
-      delete "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples/#{other_example.id}", headers: headers
+      delete "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples/#{other_example.id}",
+             headers: headers
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/requests/api/v1/meanings_spec.rb
+++ b/spec/requests/api/v1/meanings_spec.rb
@@ -1,12 +1,12 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "Api::V1::Meanings", type: :request do
+RSpec.describe 'Api::V1::Meanings', type: :request do
   let(:user) { create(:user) }
   let(:headers) { auth_headers_for(user) }
   let(:wordbook) { create(:wordbook, user: user) }
   let(:word) { create(:word, wordbook: wordbook) }
 
-  describe "GET /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings" do
+  describe 'GET /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings' do
     it "returns current user's meanings" do
       create_list(:meaning, 2, word: word)
       create(:meaning) # another user's meaning
@@ -17,7 +17,7 @@ RSpec.describe "Api::V1::Meanings", type: :request do
       expect(response.parsed_body.size).to eq(2)
     end
 
-    it "returns 401 without authentication" do
+    it 'returns 401 without authentication' do
       get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings"
 
       expect(response).to have_http_status(:unauthorized)
@@ -33,14 +33,14 @@ RSpec.describe "Api::V1::Meanings", type: :request do
     end
   end
 
-  describe "GET /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:id" do
-    it "returns the meaning" do
-      meaning = create(:meaning, word: word, content: "挨拶")
+  describe 'GET /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:id' do
+    it 'returns the meaning' do
+      meaning = create(:meaning, word: word, content: '挨拶')
 
       get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body["content"]).to eq("挨拶")
+      expect(response.parsed_body['content']).to eq('挨拶')
     end
 
     it "returns not_found for another user's meaning" do
@@ -54,43 +54,47 @@ RSpec.describe "Api::V1::Meanings", type: :request do
     end
   end
 
-  describe "POST /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings" do
-    context "with valid params" do
-      it "creates a meaning" do
-        expect {
-          post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings", params: { meaning: { content: "意味", display_order: 1 } }, headers: headers
-        }.to change(Meaning, :count).by(1)
+  describe 'POST /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings' do
+    context 'with valid params' do
+      it 'creates a meaning' do
+        expect do
+          post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings",
+               params: { meaning: { content: '意味', display_order: 1 } }, headers: headers
+        end.to change(Meaning, :count).by(1)
 
         expect(response).to have_http_status(:created)
       end
     end
 
-    context "with invalid params" do
-      it "returns unprocessable_entity" do
-        post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings", params: { meaning: { content: "", display_order: 1 } }, headers: headers
+    context 'with invalid params' do
+      it 'returns unprocessable_entity' do
+        post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings",
+             params: { meaning: { content: '', display_order: 1 } }, headers: headers
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 
-    it "returns not_found when word belongs to another user" do
+    it 'returns not_found when word belongs to another user' do
       other_wordbook = create(:wordbook)
       other_word = create(:word, wordbook: other_wordbook)
 
-      post "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings", params: { meaning: { content: "test", display_order: 1 } }, headers: headers
+      post "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings",
+           params: { meaning: { content: 'test', display_order: 1 } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "PATCH /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:id" do
+  describe 'PATCH /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:id' do
     let(:meaning) { create(:meaning, word: word) }
 
-    it "updates the meaning" do
-      patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}", params: { meaning: { content: "更新された意味" } }, headers: headers
+    it 'updates the meaning' do
+      patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}",
+            params: { meaning: { content: '更新された意味' } }, headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body["content"]).to eq("更新された意味")
+      expect(response.parsed_body['content']).to eq('更新された意味')
     end
 
     it "returns not_found for another user's meaning" do
@@ -98,19 +102,20 @@ RSpec.describe "Api::V1::Meanings", type: :request do
       other_word = create(:word, wordbook: other_wordbook)
       other_meaning = create(:meaning, word: other_word)
 
-      patch "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings/#{other_meaning.id}", params: { meaning: { content: "hacked" } }, headers: headers
+      patch "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings/#{other_meaning.id}",
+            params: { meaning: { content: 'hacked' } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "DELETE /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:id" do
-    it "deletes the meaning" do
+  describe 'DELETE /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:id' do
+    it 'deletes the meaning' do
       meaning = create(:meaning, word: word)
 
-      expect {
+      expect do
         delete "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}", headers: headers
-      }.to change(Meaning, :count).by(-1)
+      end.to change(Meaning, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end
@@ -120,7 +125,8 @@ RSpec.describe "Api::V1::Meanings", type: :request do
       other_word = create(:word, wordbook: other_wordbook)
       other_meaning = create(:meaning, word: other_word)
 
-      delete "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings/#{other_meaning.id}", headers: headers
+      delete "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings/#{other_meaning.id}",
+             headers: headers
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -1,38 +1,38 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "Api::V1::Settings", type: :request do
+RSpec.describe 'Api::V1::Settings', type: :request do
   let(:user) { create(:user) }
   let(:headers) { auth_headers_for(user) }
 
-  describe "GET /api/v1/setting" do
+  describe 'GET /api/v1/setting' do
     it "returns the current user's setting" do
-      setting = create(:setting, user: user)
+      create(:setting, user: user)
 
-      get "/api/v1/setting", headers: headers
+      get '/api/v1/setting', headers: headers
 
       expect(response).to have_http_status(:ok)
       body = response.parsed_body
-      expect(body["hard_interval"]).to eq({ "days" => 1, "hours" => 0, "minutes" => 0 })
-      expect(body["uncertain_interval"]).to eq({ "days" => 3, "hours" => 0, "minutes" => 0 })
-      expect(body["easy_interval"]).to eq({ "days" => 7, "hours" => 0, "minutes" => 0 })
+      expect(body['hard_interval']).to eq({ 'days' => 1, 'hours' => 0, 'minutes' => 0 })
+      expect(body['uncertain_interval']).to eq({ 'days' => 3, 'hours' => 0, 'minutes' => 0 })
+      expect(body['easy_interval']).to eq({ 'days' => 7, 'hours' => 0, 'minutes' => 0 })
     end
 
-    it "returns not_found when user has no setting" do
-      get "/api/v1/setting", headers: headers
+    it 'returns not_found when user has no setting' do
+      get '/api/v1/setting', headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
 
-    it "returns 401 without authentication" do
-      get "/api/v1/setting"
+    it 'returns 401 without authentication' do
+      get '/api/v1/setting'
 
       expect(response).to have_http_status(:unauthorized)
     end
   end
 
-  describe "POST /api/v1/setting" do
-    context "with valid params" do
-      it "creates a setting for the current user" do
+  describe 'POST /api/v1/setting' do
+    context 'with valid params' do
+      it 'creates a setting for the current user' do
         params = {
           setting: {
             hard_interval: { days: 1, hours: 0, minutes: 0 },
@@ -41,52 +41,52 @@ RSpec.describe "Api::V1::Settings", type: :request do
           }
         }
 
-        expect {
-          post "/api/v1/setting", params: params, headers: headers
-        }.to change(Setting, :count).by(1)
+        expect do
+          post '/api/v1/setting', params: params, headers: headers
+        end.to change(Setting, :count).by(1)
 
         expect(response).to have_http_status(:created)
         expect(Setting.last.user_id).to eq(user.id)
       end
     end
 
-    context "with missing intervals" do
-      it "returns unprocessable_entity" do
+    context 'with missing intervals' do
+      it 'returns unprocessable_entity' do
         params = {
           setting: {
             hard_interval: { days: 1, hours: 0, minutes: 0 }
           }
         }
 
-        post "/api/v1/setting", params: params, headers: headers
+        post '/api/v1/setting', params: params, headers: headers
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end
 
-  describe "PATCH /api/v1/setting" do
+  describe 'PATCH /api/v1/setting' do
     let!(:setting) { create(:setting, user: user) }
 
-    it "updates the setting" do
-      patch "/api/v1/setting", params: {
+    it 'updates the setting' do
+      patch '/api/v1/setting', params: {
         setting: {
           hard_interval: { days: 2, hours: 0, minutes: 0 }
         }
       }, headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body["hard_interval"]).to eq({ "days" => 2, "hours" => 0, "minutes" => 0 })
+      expect(response.parsed_body['hard_interval']).to eq({ 'days' => 2, 'hours' => 0, 'minutes' => 0 })
     end
   end
 
-  describe "DELETE /api/v1/setting" do
-    it "deletes the setting" do
-      setting = create(:setting, user: user)
+  describe 'DELETE /api/v1/setting' do
+    it 'deletes the setting' do
+      create(:setting, user: user)
 
-      expect {
-        delete "/api/v1/setting", headers: headers
-      }.to change(Setting, :count).by(-1)
+      expect do
+        delete '/api/v1/setting', headers: headers
+      end.to change(Setting, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end

--- a/spec/requests/api/v1/test/words_spec.rb
+++ b/spec/requests/api/v1/test/words_spec.rb
@@ -1,72 +1,72 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "Api::V1::Test::Words", type: :request do
+RSpec.describe 'Api::V1::Test::Words', type: :request do
   let(:user) { create(:user) }
   let(:headers) { auth_headers_for(user) }
   let(:wordbook) { create(:wordbook, user: user) }
 
-  describe "GET /api/v1/wordbooks/:wordbook_id/test/words" do
-    it "returns reviewable words with meanings and examples" do
+  describe 'GET /api/v1/wordbooks/:wordbook_id/test/words' do
+    it 'returns reviewable words with meanings and examples' do
       word = create(:word, wordbook: wordbook, next_review_at: nil)
-      meaning = create(:meaning, word: word, content: "りんご", display_order: 1)
-      example = create(:example, word: word, sentence: "I like apples.", display_order: 1)
+      create(:meaning, word: word, content: 'りんご', display_order: 1)
+      create(:example, word: word, sentence: 'I like apples.', display_order: 1)
 
       get "/api/v1/wordbooks/#{wordbook.id}/test/words", headers: headers
 
       expect(response).to have_http_status(:ok)
       body = response.parsed_body
-      expect(body["wordbook"]["id"]).to eq(wordbook.id)
-      expect(body["wordbook"]["title"]).to eq(wordbook.title)
-      expect(body["words"].size).to eq(1)
+      expect(body['wordbook']['id']).to eq(wordbook.id)
+      expect(body['wordbook']['title']).to eq(wordbook.title)
+      expect(body['words'].size).to eq(1)
 
-      returned_word = body["words"].first
-      expect(returned_word["spelling"]).to eq(word.spelling)
-      expect(returned_word["meanings"].size).to eq(1)
-      expect(returned_word["meanings"].first["content"]).to eq("りんご")
-      expect(returned_word["examples"].size).to eq(1)
-      expect(returned_word["examples"].first["sentence"]).to eq("I like apples.")
+      returned_word = body['words'].first
+      expect(returned_word['spelling']).to eq(word.spelling)
+      expect(returned_word['meanings'].size).to eq(1)
+      expect(returned_word['meanings'].first['content']).to eq('りんご')
+      expect(returned_word['examples'].size).to eq(1)
+      expect(returned_word['examples'].first['sentence']).to eq('I like apples.')
     end
 
-    it "includes words with next_review_at in the past" do
-      word = create(:word, wordbook: wordbook, next_review_at: 1.day.ago)
+    it 'includes words with next_review_at in the past' do
+      create(:word, wordbook: wordbook, next_review_at: 1.day.ago)
 
       get "/api/v1/wordbooks/#{wordbook.id}/test/words", headers: headers
 
-      expect(response.parsed_body["words"].size).to eq(1)
+      expect(response.parsed_body['words'].size).to eq(1)
     end
 
-    it "excludes words with next_review_at in the future" do
+    it 'excludes words with next_review_at in the future' do
       create(:word, wordbook: wordbook, next_review_at: 1.day.from_now)
 
       get "/api/v1/wordbooks/#{wordbook.id}/test/words", headers: headers
 
-      expect(response.parsed_body["words"].size).to eq(0)
+      expect(response.parsed_body['words'].size).to eq(0)
     end
 
-    it "returns meanings and examples sorted by display_order" do
+    it 'returns meanings and examples sorted by display_order' do
       word = create(:word, wordbook: wordbook, next_review_at: nil)
-      create(:meaning, word: word, content: "second", display_order: 2)
-      create(:meaning, word: word, content: "first", display_order: 1)
-      create(:example, word: word, sentence: "Second", display_order: 2)
-      create(:example, word: word, sentence: "First", display_order: 1)
+      create(:meaning, word: word, content: 'second', display_order: 2)
+      create(:meaning, word: word, content: 'first', display_order: 1)
+      create(:example, word: word, sentence: 'Second', display_order: 2)
+      create(:example, word: word, sentence: 'First', display_order: 1)
 
       get "/api/v1/wordbooks/#{wordbook.id}/test/words", headers: headers
 
-      returned_word = response.parsed_body["words"].first
-      expect(returned_word["meanings"].map { |m| m["content"] }).to eq(%w[first second])
-      expect(returned_word["examples"].map { |e| e["sentence"] }).to eq(%w[First Second])
+      returned_word = response.parsed_body['words'].first
+      expect(returned_word['meanings'].pluck('content')).to eq(%w[first second])
+      expect(returned_word['examples'].pluck('sentence')).to eq(%w[First Second])
     end
 
-    it "returns empty words array when no reviewable words exist" do
+    it 'returns empty words array when no reviewable words exist' do
       create(:word, wordbook: wordbook, next_review_at: 1.day.from_now)
 
       get "/api/v1/wordbooks/#{wordbook.id}/test/words", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body["words"]).to eq([])
+      expect(response.parsed_body['words']).to eq([])
     end
 
-    it "returns 401 without authentication" do
+    it 'returns 401 without authentication' do
       get "/api/v1/wordbooks/#{wordbook.id}/test/words"
 
       expect(response).to have_http_status(:unauthorized)

--- a/spec/requests/api/v1/wordbooks_spec.rb
+++ b/spec/requests/api/v1/wordbooks_spec.rb
@@ -1,46 +1,46 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "Api::V1::Wordbooks", type: :request do
+RSpec.describe 'Api::V1::Wordbooks', type: :request do
   let(:user) { create(:user) }
   let(:headers) { auth_headers_for(user) }
 
-  describe "GET /api/v1/wordbooks" do
+  describe 'GET /api/v1/wordbooks' do
     it "returns current user's wordbooks" do
       create_list(:wordbook, 3, user: user)
       create(:wordbook) # another user's wordbook
 
-      get "/api/v1/wordbooks", headers: headers
+      get '/api/v1/wordbooks', headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body.size).to eq(3)
     end
 
-    it "returns empty array when no wordbooks exist" do
-      get "/api/v1/wordbooks", headers: headers
+    it 'returns empty array when no wordbooks exist' do
+      get '/api/v1/wordbooks', headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq([])
     end
 
-    it "returns 401 without authentication" do
-      get "/api/v1/wordbooks"
+    it 'returns 401 without authentication' do
+      get '/api/v1/wordbooks'
 
       expect(response).to have_http_status(:unauthorized)
     end
   end
 
-  describe "GET /api/v1/wordbooks/:id" do
-    it "returns the wordbook" do
+  describe 'GET /api/v1/wordbooks/:id' do
+    it 'returns the wordbook' do
       wordbook = create(:wordbook, user: user)
 
       get "/api/v1/wordbooks/#{wordbook.id}", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body["title"]).to eq(wordbook.title)
+      expect(response.parsed_body['title']).to eq(wordbook.title)
     end
 
-    it "returns not_found for nonexistent wordbook" do
-      get "/api/v1/wordbooks/999999", headers: headers
+    it 'returns not_found for nonexistent wordbook' do
+      get '/api/v1/wordbooks/999999', headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
@@ -54,44 +54,44 @@ RSpec.describe "Api::V1::Wordbooks", type: :request do
     end
   end
 
-  describe "POST /api/v1/wordbooks" do
-    context "with valid params" do
-      it "creates a wordbook for the current user" do
-        expect {
-          post "/api/v1/wordbooks", params: { wordbook: { title: "English Vocab" } }, headers: headers
-        }.to change(Wordbook, :count).by(1)
+  describe 'POST /api/v1/wordbooks' do
+    context 'with valid params' do
+      it 'creates a wordbook for the current user' do
+        expect do
+          post '/api/v1/wordbooks', params: { wordbook: { title: 'English Vocab' } }, headers: headers
+        end.to change(Wordbook, :count).by(1)
 
         expect(response).to have_http_status(:created)
-        expect(response.parsed_body["title"]).to eq("English Vocab")
-        expect(response.parsed_body["user_id"]).to eq(user.id)
+        expect(response.parsed_body['title']).to eq('English Vocab')
+        expect(response.parsed_body['user_id']).to eq(user.id)
       end
     end
 
-    context "with invalid params" do
-      it "returns unprocessable_entity" do
-        post "/api/v1/wordbooks", params: { wordbook: { title: "" } }, headers: headers
+    context 'with invalid params' do
+      it 'returns unprocessable_entity' do
+        post '/api/v1/wordbooks', params: { wordbook: { title: '' } }, headers: headers
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(response.parsed_body["errors"]).to include("Title can't be blank")
+        expect(response.parsed_body['errors']).to include("Title can't be blank")
       end
     end
   end
 
-  describe "PATCH /api/v1/wordbooks/:id" do
+  describe 'PATCH /api/v1/wordbooks/:id' do
     let(:wordbook) { create(:wordbook, user: user) }
 
-    context "with valid params" do
-      it "updates the wordbook" do
-        patch "/api/v1/wordbooks/#{wordbook.id}", params: { wordbook: { title: "Updated Title" } }, headers: headers
+    context 'with valid params' do
+      it 'updates the wordbook' do
+        patch "/api/v1/wordbooks/#{wordbook.id}", params: { wordbook: { title: 'Updated Title' } }, headers: headers
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body["title"]).to eq("Updated Title")
+        expect(response.parsed_body['title']).to eq('Updated Title')
       end
     end
 
-    context "with invalid params" do
-      it "returns unprocessable_entity" do
-        patch "/api/v1/wordbooks/#{wordbook.id}", params: { wordbook: { title: "" } }, headers: headers
+    context 'with invalid params' do
+      it 'returns unprocessable_entity' do
+        patch "/api/v1/wordbooks/#{wordbook.id}", params: { wordbook: { title: '' } }, headers: headers
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
@@ -100,19 +100,19 @@ RSpec.describe "Api::V1::Wordbooks", type: :request do
     it "returns not_found for another user's wordbook" do
       other_wordbook = create(:wordbook)
 
-      patch "/api/v1/wordbooks/#{other_wordbook.id}", params: { wordbook: { title: "Hacked" } }, headers: headers
+      patch "/api/v1/wordbooks/#{other_wordbook.id}", params: { wordbook: { title: 'Hacked' } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "DELETE /api/v1/wordbooks/:id" do
-    it "deletes the wordbook" do
+  describe 'DELETE /api/v1/wordbooks/:id' do
+    it 'deletes the wordbook' do
       wordbook = create(:wordbook, user: user)
 
-      expect {
+      expect do
         delete "/api/v1/wordbooks/#{wordbook.id}", headers: headers
-      }.to change(Wordbook, :count).by(-1)
+      end.to change(Wordbook, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -1,11 +1,11 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "Api::V1::Words", type: :request do
+RSpec.describe 'Api::V1::Words', type: :request do
   let(:user) { create(:user) }
   let(:headers) { auth_headers_for(user) }
   let(:wordbook) { create(:wordbook, user: user) }
 
-  describe "GET /api/v1/wordbooks/:wordbook_id/words" do
+  describe 'GET /api/v1/wordbooks/:wordbook_id/words' do
     it "returns current user's words" do
       create_list(:word, 3, wordbook: wordbook)
       create(:word) # another user's word
@@ -16,27 +16,27 @@ RSpec.describe "Api::V1::Words", type: :request do
       expect(response.parsed_body.size).to eq(3)
     end
 
-    it "includes first_meaning for each word" do
+    it 'includes first_meaning for each word' do
       word = create(:word, wordbook: wordbook)
-      create(:meaning, word: word, content: "second", display_order: 2)
-      create(:meaning, word: word, content: "first", display_order: 1)
+      create(:meaning, word: word, content: 'second', display_order: 2)
+      create(:meaning, word: word, content: 'first', display_order: 1)
 
       get "/api/v1/wordbooks/#{wordbook.id}/words", headers: headers
 
-      returned_word = response.parsed_body.find { |w| w["id"] == word.id }
-      expect(returned_word["first_meaning"]["content"]).to eq("first")
-      expect(returned_word["first_meaning"]["display_order"]).to eq(1)
+      returned_word = response.parsed_body.find { |w| w['id'] == word.id }
+      expect(returned_word['first_meaning']['content']).to eq('first')
+      expect(returned_word['first_meaning']['display_order']).to eq(1)
     end
 
-    it "returns null first_meaning when word has no meanings" do
+    it 'returns null first_meaning when word has no meanings' do
       create(:word, wordbook: wordbook)
 
       get "/api/v1/wordbooks/#{wordbook.id}/words", headers: headers
 
-      expect(response.parsed_body.first["first_meaning"]).to be_nil
+      expect(response.parsed_body.first['first_meaning']).to be_nil
     end
 
-    it "returns 401 without authentication" do
+    it 'returns 401 without authentication' do
       get "/api/v1/wordbooks/#{wordbook.id}/words"
 
       expect(response).to have_http_status(:unauthorized)
@@ -51,14 +51,14 @@ RSpec.describe "Api::V1::Words", type: :request do
     end
   end
 
-  describe "GET /api/v1/wordbooks/:wordbook_id/words/:id" do
-    it "returns the word" do
-      word = create(:word, wordbook: wordbook, spelling: "apple")
+  describe 'GET /api/v1/wordbooks/:wordbook_id/words/:id' do
+    it 'returns the word' do
+      word = create(:word, wordbook: wordbook, spelling: 'apple')
 
       get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body["spelling"]).to eq("apple")
+      expect(response.parsed_body['spelling']).to eq('apple')
     end
 
     it "returns not_found for another user's word" do
@@ -70,122 +70,127 @@ RSpec.describe "Api::V1::Words", type: :request do
       expect(response).to have_http_status(:not_found)
     end
 
-    context "with include parameter" do
+    context 'with include parameter' do
       let(:word) { create(:word, wordbook: wordbook) }
 
       before do
-        create(:meaning, word: word, content: "meaning1", display_order: 2)
-        create(:meaning, word: word, content: "meaning2", display_order: 1)
-        create(:example, word: word, sentence: "Example1", display_order: 2)
-        create(:example, word: word, sentence: "Example2", display_order: 1)
+        create(:meaning, word: word, content: 'meaning1', display_order: 2)
+        create(:meaning, word: word, content: 'meaning2', display_order: 1)
+        create(:example, word: word, sentence: 'Example1', display_order: 2)
+        create(:example, word: word, sentence: 'Example2', display_order: 1)
       end
 
-      it "includes meanings when include=meanings" do
+      it 'includes meanings when include=meanings' do
         get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=meanings", headers: headers
 
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
-        expect(body["meanings"].size).to eq(2)
-        expect(body["meanings"].map { |m| m["content"] }).to eq(%w[meaning2 meaning1])
-        expect(body).not_to have_key("examples")
+        expect(body['meanings'].size).to eq(2)
+        expect(body['meanings'].pluck('content')).to eq(%w[meaning2 meaning1])
+        expect(body).not_to have_key('examples')
       end
 
-      it "includes examples when include=examples" do
+      it 'includes examples when include=examples' do
         get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=examples", headers: headers
 
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
-        expect(body["examples"].size).to eq(2)
-        expect(body["examples"].map { |e| e["sentence"] }).to eq(%w[Example2 Example1])
-        expect(body).not_to have_key("meanings")
+        expect(body['examples'].size).to eq(2)
+        expect(body['examples'].pluck('sentence')).to eq(%w[Example2 Example1])
+        expect(body).not_to have_key('meanings')
       end
 
-      it "includes both when include=meanings,examples" do
+      it 'includes both when include=meanings,examples' do
         get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=meanings,examples", headers: headers
 
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
-        expect(body["meanings"].size).to eq(2)
-        expect(body["examples"].size).to eq(2)
+        expect(body['meanings'].size).to eq(2)
+        expect(body['examples'].size).to eq(2)
       end
 
-      it "ignores invalid include values" do
+      it 'ignores invalid include values' do
         get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=wordbook,invalid", headers: headers
 
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
-        expect(body).not_to have_key("wordbook")
-        expect(body).not_to have_key("invalid")
+        expect(body).not_to have_key('wordbook')
+        expect(body).not_to have_key('invalid')
       end
 
-      it "returns standard response without include parameter" do
+      it 'returns standard response without include parameter' do
         get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}", headers: headers
 
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
-        expect(body).not_to have_key("meanings")
-        expect(body).not_to have_key("examples")
+        expect(body).not_to have_key('meanings')
+        expect(body).not_to have_key('examples')
       end
     end
   end
 
-  describe "POST /api/v1/wordbooks/:wordbook_id/words" do
-    context "with valid params" do
-      it "creates a word" do
-        expect {
-          post "/api/v1/wordbooks/#{wordbook.id}/words", params: { word: { spelling: "banana", status: "not_studied" } }, headers: headers
-        }.to change(Word, :count).by(1)
+  describe 'POST /api/v1/wordbooks/:wordbook_id/words' do
+    context 'with valid params' do
+      it 'creates a word' do
+        expect do
+          post "/api/v1/wordbooks/#{wordbook.id}/words",
+               params: { word: { spelling: 'banana', status: 'not_studied' } }, headers: headers
+        end.to change(Word, :count).by(1)
 
         expect(response).to have_http_status(:created)
-        expect(response.parsed_body["spelling"]).to eq("banana")
+        expect(response.parsed_body['spelling']).to eq('banana')
       end
     end
 
-    context "with invalid params" do
-      it "returns unprocessable_entity" do
-        post "/api/v1/wordbooks/#{wordbook.id}/words", params: { word: { spelling: "", status: "not_studied" } }, headers: headers
+    context 'with invalid params' do
+      it 'returns unprocessable_entity' do
+        post "/api/v1/wordbooks/#{wordbook.id}/words", params: { word: { spelling: '', status: 'not_studied' } },
+                                                       headers: headers
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(response.parsed_body["errors"]).to include("Spelling can't be blank")
+        expect(response.parsed_body['errors']).to include("Spelling can't be blank")
       end
     end
 
-    it "returns not_found when wordbook belongs to another user" do
+    it 'returns not_found when wordbook belongs to another user' do
       other_wordbook = create(:wordbook)
 
-      post "/api/v1/wordbooks/#{other_wordbook.id}/words", params: { word: { spelling: "test", status: "not_studied" } }, headers: headers
+      post "/api/v1/wordbooks/#{other_wordbook.id}/words",
+           params: { word: { spelling: 'test', status: 'not_studied' } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "PATCH /api/v1/wordbooks/:wordbook_id/words/:id" do
+  describe 'PATCH /api/v1/wordbooks/:wordbook_id/words/:id' do
     let(:word) { create(:word, wordbook: wordbook) }
 
-    it "updates the word" do
-      patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}", params: { word: { spelling: "cherry" } }, headers: headers
+    it 'updates the word' do
+      patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}", params: { word: { spelling: 'cherry' } },
+                                                                 headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body["spelling"]).to eq("cherry")
+      expect(response.parsed_body['spelling']).to eq('cherry')
     end
 
     it "returns not_found for another user's word" do
       other_wordbook = create(:wordbook)
       other_word = create(:word, wordbook: other_wordbook)
 
-      patch "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}", params: { word: { spelling: "hacked" } }, headers: headers
+      patch "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}", params: { word: { spelling: 'hacked' } },
+                                                                             headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "DELETE /api/v1/wordbooks/:wordbook_id/words/:id" do
-    it "deletes the word" do
+  describe 'DELETE /api/v1/wordbooks/:wordbook_id/words/:id' do
+    it 'deletes the word' do
       word = create(:word, wordbook: wordbook)
 
-      expect {
+      expect do
         delete "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}", headers: headers
-      }.to change(Word, :count).by(-1)
+      end.to change(Word, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,59 +1,59 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "Authentication", type: :request do
-  describe "protected endpoints" do
+RSpec.describe 'Authentication', type: :request do
+  describe 'protected endpoints' do
     let(:user) { create(:user) }
     let!(:wordbook) { create(:wordbook, user: user) }
 
-    context "without Authorization header" do
-      it "returns 401" do
-        get "/api/v1/wordbooks"
+    context 'without Authorization header' do
+      it 'returns 401' do
+        get '/api/v1/wordbooks'
 
         expect(response).to have_http_status(:unauthorized)
-        expect(response.parsed_body["error"]).to eq("Unauthorized")
+        expect(response.parsed_body['error']).to eq('Unauthorized')
       end
     end
 
-    context "with invalid token" do
-      it "returns 401" do
-        get "/api/v1/wordbooks", headers: { "Authorization" => "Bearer invalid_token" }
+    context 'with invalid token' do
+      it 'returns 401' do
+        get '/api/v1/wordbooks', headers: { 'Authorization' => 'Bearer invalid_token' }
 
         expect(response).to have_http_status(:unauthorized)
-        expect(response.parsed_body["error"]).to eq("Unauthorized")
+        expect(response.parsed_body['error']).to eq('Unauthorized')
       end
     end
 
-    context "with expired token" do
-      it "returns 401" do
+    context 'with expired token' do
+      it 'returns 401' do
         token = JWT.encode(
           { sub: user.id, exp: 1.day.ago.to_i, iat: 2.days.ago.to_i },
           Rails.application.secret_key_base,
-          "HS256"
+          'HS256'
         )
 
-        get "/api/v1/wordbooks", headers: { "Authorization" => "Bearer #{token}" }
+        get '/api/v1/wordbooks', headers: { 'Authorization' => "Bearer #{token}" }
 
         expect(response).to have_http_status(:unauthorized)
       end
     end
 
-    context "with token for nonexistent user" do
-      it "returns 401" do
+    context 'with token for nonexistent user' do
+      it 'returns 401' do
         token = JWT.encode(
-          { sub: 999999, exp: 30.days.from_now.to_i, iat: Time.current.to_i },
+          { sub: 999_999, exp: 30.days.from_now.to_i, iat: Time.current.to_i },
           Rails.application.secret_key_base,
-          "HS256"
+          'HS256'
         )
 
-        get "/api/v1/wordbooks", headers: { "Authorization" => "Bearer #{token}" }
+        get '/api/v1/wordbooks', headers: { 'Authorization' => "Bearer #{token}" }
 
         expect(response).to have_http_status(:unauthorized)
       end
     end
 
-    context "with valid token" do
-      it "allows access" do
-        get "/api/v1/wordbooks", headers: auth_headers_for(user)
+    context 'with valid token' do
+      it 'allows access' do
+        get '/api/v1/wordbooks', headers: auth_headers_for(user)
 
         expect(response).to have_http_status(:ok)
       end

--- a/spec/requests/error_handling_spec.rb
+++ b/spec/requests/error_handling_spec.rb
@@ -1,24 +1,24 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "Error handling", type: :request do
+RSpec.describe 'Error handling', type: :request do
   let(:user) { create(:user) }
   let(:headers) { auth_headers_for(user) }
 
-  describe "ActionController::ParameterMissing" do
-    it "returns bad_request when required parameter key is missing" do
-      post "/api/v1/wordbooks", params: {}, headers: headers
+  describe 'ActionController::ParameterMissing' do
+    it 'returns bad_request when required parameter key is missing' do
+      post '/api/v1/wordbooks', params: {}, headers: headers
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body["error"]).to be_present
+      expect(response.parsed_body['error']).to be_present
     end
   end
 
-  describe "ActiveRecord::RecordNotFound" do
-    it "returns not_found for nonexistent resource" do
-      get "/api/v1/wordbooks/999999", headers: headers
+  describe 'ActiveRecord::RecordNotFound' do
+    it 'returns not_found for nonexistent resource' do
+      get '/api/v1/wordbooks/999999', headers: headers
 
       expect(response).to have_http_status(:not_found)
-      expect(response.parsed_body["error"]).to eq("Not found")
+      expect(response.parsed_body['error']).to eq('Not found')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,51 +44,49 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -3,9 +3,9 @@ module AuthenticationHelper
     token = JWT.encode(
       { sub: user.id, exp: 30.days.from_now.to_i, iat: Time.current.to_i },
       Rails.application.secret_key_base,
-      "HS256"
+      'HS256'
     )
-    { "Authorization" => "Bearer #{token}" }
+    { 'Authorization' => "Bearer #{token}" }
   end
 end
 


### PR DESCRIPTION
## Summary
- Replace `rubocop-rails-omakase` with standard `rubocop`, `rubocop-rails`, `rubocop-performance`, and `rubocop-rspec` gems
- Configure RuboCop with general settings: all cops enabled by default, Metrics/Naming disabled to reduce noise
- Fix all existing rubocop offenses across app, config, and spec files

Closes #28