### PR TITLE
fix: remove unnecessary StandardError rescue in GoogleAuthenticatable

### DIFF
--- a/app/controllers/concerns/google_authenticatable.rb
+++ b/app/controllers/concerns/google_authenticatable.rb
@@ -11,9 +11,6 @@ module GoogleAuthenticatable
     rescue Google::Auth::IDTokens::VerificationError => e
       Rails.logger.error("Google ID token verification failed: #{e.message}")
       nil
-    rescue StandardError => e
-      Rails.logger.error("Unexpected error: #{e.message}")
-      nil
     end
   end
 end

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -79,6 +79,20 @@ RSpec.describe 'Api::V1::Auth', type: :request do
       end
     end
 
+    context 'when an unexpected error occurs during token verification' do
+      before do
+        allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_raise(
+          RuntimeError.new('Unexpected network error')
+        )
+      end
+
+      it 'raises the error instead of returning unauthorized' do
+        expect do
+          post '/api/v1/auth/google', headers: { 'Authorization' => 'Bearer valid_token' }
+        end.to raise_error(RuntimeError, 'Unexpected network error')
+      end
+    end
+
     context 'when token is valid and user is new' do
       before do
         allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return(google_payload)


### PR DESCRIPTION
## Summary
- Remove the `rescue StandardError` block from `verify_google_token` so unexpected errors (e.g., network failures, OpenSSL errors) propagate to `ApplicationController`'s `rescue_from StandardError` and return a proper 500 instead of being silently swallowed as 401
- Add a test to verify that unexpected errors are raised instead of being caught

Closes #56