### PR TITLE
refactor: use ActiveSupport::Duration#parts in duration_to_hash

### DIFF
--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -77,12 +77,7 @@ module Api
       def duration_to_hash(duration)
         return nil if duration.blank?
 
-        total_seconds = duration.to_i
-        days = total_seconds / 86_400
-        hours = (total_seconds % 86_400) / 3600
-        minutes = (total_seconds % 3600) / 60
-
-        { days: days, hours: hours, minutes: minutes }
+        { days: 0, hours: 0, minutes: 0 }.merge(duration.parts.slice(:days, :hours, :minutes))
       end
     end
   end


### PR DESCRIPTION
Closes #61

Refactors `SettingsController#duration_to_hash` to use `ActiveSupport::Duration#parts` instead of manual arithmetic.

- Uses `duration.parts` for native decomposition
- Merges default zero values to always return all three keys (`days`, `hours`, `minutes`)
- Uses `.slice` to exclude unexpected keys (e.g. `:seconds`, `:weeks`)

Generated with [Claude Code](https://claude.ai/code)