### PR TITLE
feat: return default setting values from API for users without a Setting record

### DIFF
--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -1,10 +1,10 @@
 module Api
   module V1
     class SettingsController < ApplicationController
-      before_action :set_setting, only: %i[show update destroy]
+      before_action :set_setting, only: %i[update destroy]
 
       def show
-        render json: setting_response(@setting)
+        render json: setting_response(current_user.effective_setting)
       end
 
       def create

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,4 +1,14 @@
 class Setting < ApplicationRecord
+  DefaultSetting = Struct.new(:hard_interval, :uncertain_interval, :easy_interval) do
+    def as_json(*)
+      {}
+    end
+  end
+
+  def self.default
+    DefaultSetting.new(1.day, 3.days, 7.days)
+  end
+
   belongs_to :user
 
   validates :hard_interval, :uncertain_interval, :easy_interval, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,8 @@ class User < ApplicationRecord
   validates :guest_expires_at, presence: true, if: -> { provider == 'guest' }
 
   enum :provider, { google: 'google', guest: 'guest' }
+
+  def effective_setting
+    setting || Setting.default
+  end
 end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Setting, type: :model do
   end
 
   describe '.default' do
-    subject(:default_setting) { Setting.default }
+    subject(:default_setting) { described_class.default }
 
     it 'returns a DefaultSetting with hard_interval of 1 day' do
       expect(default_setting.hard_interval).to eq(1.day)

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -31,4 +31,24 @@ RSpec.describe Setting, type: :model do
       expect(build(:setting)).to be_valid
     end
   end
+
+  describe '.default' do
+    subject(:default_setting) { Setting.default }
+
+    it 'returns a DefaultSetting with hard_interval of 1 day' do
+      expect(default_setting.hard_interval).to eq(1.day)
+    end
+
+    it 'returns a DefaultSetting with uncertain_interval of 3 days' do
+      expect(default_setting.uncertain_interval).to eq(3.days)
+    end
+
+    it 'returns a DefaultSetting with easy_interval of 7 days' do
+      expect(default_setting.easy_interval).to eq(7.days)
+    end
+
+    it 'returns an empty hash for as_json' do
+      expect(default_setting.as_json).to eq({})
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,4 +67,22 @@ RSpec.describe User, type: :model do
       expect(build(:user, :guest)).to be_valid
     end
   end
+
+  describe '#effective_setting' do
+    let(:user) { create(:user) }
+
+    context 'when user has a setting record' do
+      let!(:setting) { create(:setting, user: user) }
+
+      it 'returns the user setting' do
+        expect(user.effective_setting).to eq(setting)
+      end
+    end
+
+    context 'when user has no setting record' do
+      it 'returns the default setting' do
+        expect(user.effective_setting).to eq(Setting.default)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -17,10 +17,14 @@ RSpec.describe 'Api::V1::Settings', type: :request do
       expect(body['easy_interval']).to eq({ 'days' => 7, 'hours' => 0, 'minutes' => 0 })
     end
 
-    it 'returns not_found when user has no setting' do
+    it 'returns default values when user has no setting' do
       get '/api/v1/setting', headers: headers
 
-      expect(response).to have_http_status(:not_found)
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body['hard_interval']).to eq({ 'days' => 1, 'hours' => 0, 'minutes' => 0 })
+      expect(body['uncertain_interval']).to eq({ 'days' => 3, 'hours' => 0, 'minutes' => 0 })
+      expect(body['easy_interval']).to eq({ 'days' => 7, 'hours' => 0, 'minutes' => 0 })
     end
 
     it 'returns 401 without authentication' do


### PR DESCRIPTION
Closes #63

## Summary

- Added the `Setting.default` class method (value object based on the `DefaultSetting` struct)
- Added the `User#effective_setting` method (falls back to the default value if no Setting record exists)
- Modified `GET /api/v1/setting` to return the default value even for users without a Setting record