### PR TITLE
refactor: filter Wordbook/Word response fields

### DIFF
--- a/app/controllers/api/v1/wordbooks_controller.rb
+++ b/app/controllers/api/v1/wordbooks_controller.rb
@@ -5,18 +5,18 @@ module Api
 
       def index
         wordbooks = current_user.wordbooks
-        render json: wordbooks
+        render json: wordbooks.as_json(only: Wordbook::API_FIELDS)
       end
 
       def show
-        render json: @wordbook
+        render json: @wordbook.as_json(only: Wordbook::API_FIELDS)
       end
 
       def create
         wordbook = current_user.wordbooks.new(wordbook_params)
 
         if wordbook.save
-          render json: wordbook, status: :created
+          render json: wordbook.as_json(only: Wordbook::API_FIELDS), status: :created
         else
           render json: { errors: wordbook.errors.full_messages }, status: :unprocessable_content
         end
@@ -24,7 +24,7 @@ module Api
 
       def update
         if @wordbook.update(wordbook_params)
-          render json: @wordbook
+          render json: @wordbook.as_json(only: Wordbook::API_FIELDS)
         else
           render json: { errors: @wordbook.errors.full_messages }, status: :unprocessable_content
         end

--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -7,7 +7,7 @@ module Api
       def index
         words = @wordbook.words.includes(:first_meaning)
         render json: words.map { |word|
-          word.as_json.merge(first_meaning: word.first_meaning&.as_json)
+          word.as_json(only: Word::API_FIELDS).merge(first_meaning: word.first_meaning&.as_json(only: [:content]))
         }
       end
 
@@ -21,7 +21,7 @@ module Api
         word = @wordbook.words.new(word_params)
 
         if word.save
-          render json: word, status: :created
+          render json: word.as_json(only: Word::API_FIELDS), status: :created
         else
           render json: { errors: word.errors.full_messages }, status: :unprocessable_content
         end
@@ -29,7 +29,7 @@ module Api
 
       def update
         if @word.update(word_params)
-          render json: @word
+          render json: @word.as_json(only: Word::API_FIELDS)
         else
           render json: { errors: @word.errors.full_messages }, status: :unprocessable_content
         end
@@ -59,7 +59,7 @@ module Api
       end
 
       def word_json(word, includes: [])
-        json = word.as_json
+        json = word.as_json(only: Word::API_FIELDS)
         includes.each do |assoc|
           json[assoc] = word.public_send(assoc).sort_by(&:display_order).as_json
         end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -10,4 +10,6 @@ class Word < ApplicationRecord
   enum :status, { not_studied: 'not_studied', hard: 'hard', uncertain: 'uncertain', easy: 'easy' }
 
   scope :reviewable, -> { where('next_review_at IS NULL OR next_review_at <= ?', Time.current) }
+
+  API_FIELDS = %i[id spelling status next_review_at].freeze
 end

--- a/app/models/wordbook.rb
+++ b/app/models/wordbook.rb
@@ -3,4 +3,6 @@ class Wordbook < ApplicationRecord
   has_many :words, dependent: :destroy
 
   validates :title, presence: true
+
+  API_FIELDS = %i[id title created_at].freeze
 end

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -906,14 +906,9 @@ components:
       properties:
         id:
           type: integer
-        user_id:
-          type: integer
         title:
           type: string
         created_at:
-          type: string
-          format: date-time
-        updated_at:
           type: string
           format: date-time
 
@@ -921,8 +916,6 @@ components:
       type: object
       properties:
         id:
-          type: integer
-        wordbook_id:
           type: integer
         spelling:
           type: string
@@ -932,12 +925,6 @@ components:
           type: string
           format: date-time
           nullable: true
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
 
     WordWithFirstMeaning:
       allOf:
@@ -947,8 +934,10 @@ components:
             first_meaning:
               nullable: true
               description: The meaning with the lowest display_order, or null if no meanings exist
-              allOf:
-                - $ref: "#/components/schemas/Meaning"
+              type: object
+              properties:
+                content:
+                  type: string
 
     WordWithRelations:
       allOf:

--- a/spec/requests/api/v1/wordbooks_spec.rb
+++ b/spec/requests/api/v1/wordbooks_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe 'Api::V1::Wordbooks', type: :request do
 
         expect(response).to have_http_status(:created)
         expect(response.parsed_body['title']).to eq('English Vocab')
-        expect(response.parsed_body['user_id']).to eq(user.id)
       end
     end
 

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe 'Api::V1::Words', type: :request do
 
       returned_word = response.parsed_body.find { |w| w['id'] == word.id }
       expect(returned_word['first_meaning']['content']).to eq('first')
-      expect(returned_word['first_meaning']['display_order']).to eq(1)
     end
 
     it 'returns null first_meaning when word has no meanings' do


### PR DESCRIPTION
Apply `as_json(only:)` to Wordbook and Word responses to remove unused fields.

Closes #80

Generated with [Claude Code](https://claude.ai/code)