### PR TITLE
fix: compare Setting attributes instead of object identity in spec

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe User, type: :model do
 
     context 'when user has no setting record' do
       it 'returns the default setting' do
-        expect(user.effective_setting).to eq(Setting.default)
+        expect(user.effective_setting.attributes).to eq(Setting.default.attributes)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Fix failing `User#effective_setting` spec by comparing `attributes` hashes instead of object identity
- `Setting.default` creates a new instance each time, so ActiveRecord's `==` for unsaved records (which uses object identity) always returns false