### PR TITLE
Migrate error handling to exceptions_app

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -3,10 +3,6 @@ module Api
     class AuthController < ApplicationController
       skip_before_action :authenticate_user!
 
-      rescue_from GoogleIdToken::VerificationError do
-        render json: { error: 'Invalid ID token' }, status: :unauthorized
-      end
-
       def guest
         user = User.create!(provider: 'guest', guest_expires_at: 7.days.from_now)
         token = JsonWebToken.encode(user.id, expires_at: user.guest_expires_at)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,23 +1,3 @@
 class ApplicationController < ActionController::API
   include Authenticatable
-
-  if Rails.env.production?
-    rescue_from StandardError do |e|
-      Rails.logger.error("Unhandled error: #{e.class} - #{e.message}")
-      Rails.logger.error(e.backtrace&.first(10)&.join("\n"))
-      render json: { error: 'Internal server error' }, status: :internal_server_error
-    end
-  end
-
-  rescue_from ActiveRecord::RecordNotFound do
-    render json: { error: 'Not found' }, status: :not_found
-  end
-
-  rescue_from ActiveRecord::RecordNotUnique do
-    render json: { error: 'Duplicate record' }, status: :conflict
-  end
-
-  rescue_from ActionController::ParameterMissing do |e|
-    render json: { error: e.message }, status: :bad_request
-  end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,33 @@
+class ErrorsController < ActionController::API
+  def show
+    status = params[:status].to_i
+    render json: { error: error_message(status) }, status: status
+  end
+
+  private
+
+  def error_message(status)
+    exception = request.env['action_dispatch.exception']
+
+    case status
+    when 400
+      exception&.message || 'Bad request'
+    when 401
+      exception.is_a?(GoogleIdToken::VerificationError) ? 'Invalid ID token' : 'Unauthorized'
+    when 404
+      'Not found'
+    when 409
+      'Duplicate record'
+    when 500
+      log_server_error(exception) if exception
+      'Internal server error'
+    else
+      Rack::Utils::HTTP_STATUS_CODES.fetch(status, 'Unknown error')
+    end
+  end
+
+  def log_server_error(exception)
+    Rails.logger.error("Unhandled error: #{exception.class} - #{exception.message}")
+    Rails.logger.error(exception.backtrace&.first(10)&.join("\n"))
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,12 @@ module WordbeetleApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.exceptions_app = routes
+
+    config.action_dispatch.rescue_responses.merge!(
+      'ActiveRecord::RecordNotUnique' => :conflict,
+      'GoogleIdToken::VerificationError' => :unauthorized
+    )
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,8 +18,9 @@ Rails.application.configure do
   # Configure public file server for tests with cache-control for performance.
   config.public_file_server.headers = { 'cache-control' => 'public, max-age=3600' }
 
-  # Show full error reports.
-  config.consider_all_requests_local = true
+  # Let exceptions flow through exceptions_app (ErrorsController) instead of
+  # being intercepted by DebugExceptions middleware.
+  config.consider_all_requests_local = false
   config.cache_store = :null_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,6 @@ Rails.application.routes.draw do
     end
   end
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  # Error handling (must be last)
+  match '/:status', to: 'errors#show', via: :all, constraints: { status: /\d{3}/ }
 end

--- a/spec/requests/error_handling_spec.rb
+++ b/spec/requests/error_handling_spec.rb
@@ -21,4 +21,17 @@ RSpec.describe 'Error handling', type: :request do
       expect(response.parsed_body['error']).to eq('Not found')
     end
   end
+
+  describe 'ActiveRecord::RecordNotUnique' do
+    it 'returns conflict for duplicate record' do
+      allow(Wordbook).to receive(:new).and_raise(
+        ActiveRecord::RecordNotUnique.new('Duplicate entry')
+      )
+
+      post '/api/v1/wordbooks', params: { wordbook: { title: 'Test' } }, headers: headers
+
+      expect(response).to have_http_status(:conflict)
+      expect(response.parsed_body['error']).to eq('Duplicate record')
+    end
+  end
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'Errors', type: :request do
+  describe 'unknown routes' do
+    it 'returns not_found for nonexistent GET path' do
+      get '/nonexistent/path'
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body['error']).to eq('Not found')
+      expect(response.content_type).to include('application/json')
+    end
+
+    it 'returns not_found for nonexistent POST path' do
+      post '/nonexistent/path'
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body['error']).to eq('Not found')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `ErrorsController` for centralized JSON error rendering, replacing `rescue_from` blocks in `ApplicationController` and `AuthController`
- Configure `config.exceptions_app = routes` with custom `rescue_responses` mappings for `ActiveRecord::RecordNotUnique` (409) and `GoogleIdToken::VerificationError` (401)
- Routing errors (unknown paths) now return JSON 404 instead of HTML

## Changes

- **New:** `app/controllers/errors_controller.rb` — Inherits from `ActionController::API` directly to avoid authentication concern
- **New:** `spec/requests/errors_spec.rb` — Tests for unknown route handling
- **Modified:** `config/application.rb` — `exceptions_app` and `rescue_responses` configuration
- **Modified:** `config/routes.rb` — Catch-all error route
- **Modified:** `config/environments/test.rb` — Set `consider_all_requests_local = false` so `DebugExceptions` middleware does not intercept rescuable exceptions
- **Modified:** `app/controllers/application_controller.rb` — Removed all `rescue_from` blocks
- **Modified:** `app/controllers/api/v1/auth_controller.rb` — Removed `rescue_from GoogleIdToken::VerificationError`
- **Modified:** `spec/requests/error_handling_spec.rb` — Added `RecordNotUnique` test case

## Test plan

- [x] `bundle exec rspec spec/requests/error_handling_spec.rb` — ParameterMissing (400), RecordNotFound (404), RecordNotUnique (409)
- [x] `bundle exec rspec spec/requests/errors_spec.rb` — Unknown route returns 404 JSON
- [x] `bundle exec rspec spec/requests/api/v1/auth_spec.rb` — Invalid ID token (401), RuntimeError propagation
- [x] `bundle exec rspec spec/requests/authentication_spec.rb` — Unauthorized (401) via Authenticatable concern
- [x] Full suite: no new failures introduced

Closes #70