### PR TITLE
Fix failing tests: Alba 3.x compatibility and guest token validation

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -43,7 +43,7 @@ module Api
       def handle_guest_migration(google_payload)
         guest_user = User.find_by_token(params[:guest_token])
 
-        return render json: { error: 'Invalid guest token' }, status: :unauthorized unless guest_user
+        return render json: { error: 'Invalid guest token' }, status: :unauthorized unless guest_user&.guest?
 
         result = guest_user.migrate_to_google(google_payload)
 

--- a/app/resources/word_resource.rb
+++ b/app/resources/word_resource.rb
@@ -3,17 +3,17 @@ class WordResource
 
   attributes :id, :spelling, :status, :next_review_at
 
-  attribute :first_meaning, if: proc { |_word, params| params[:include_first_meaning] } do |word|
+  attribute :first_meaning, if: proc { |_word| params[:include_first_meaning] } do |word|
     word.first_meaning ? { definition: word.first_meaning.definition } : nil
   end
 
-  attribute :meanings, if: proc { |_word, params| params[:includes]&.include?('meanings') } do |word|
+  attribute :meanings, if: proc { |_word| params[:includes]&.include?('meanings') } do |word|
     word.meanings.sort_by(&:display_order).map do |m|
       { id: m.id, definition: m.definition, display_order: m.display_order }
     end
   end
 
-  attribute :examples, if: proc { |_word, params| params[:includes]&.include?('examples') } do |word|
+  attribute :examples, if: proc { |_word| params[:includes]&.include?('examples') } do |word|
     word.examples.sort_by(&:display_order).map do |e|
       { id: e.id, sentence: e.sentence, translation: e.translation, display_order: e.display_order }
     end


### PR DESCRIPTION
## Summary
- Update WordResource `if` procs from arity 2 to arity 1 for Alba 3.x API compatibility. In Alba 3.x, the second argument to the `if` proc is the attribute value, not params.
- Add `guest?` check in `AuthController#handle_guest_migration` so that a non-guest user's token passed as `guest_token` correctly returns 401 instead of 422.

## Test plan
- [x] `bundle exec rspec` — all 199 examples pass