### PR TITLE
Fix Claude Code action auth failure caused by additional_permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -62,7 +62,4 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
-            contents: write
-            pull-requests: write
-            issues: write
 


### PR DESCRIPTION
## Summary

- Revert `additional_permissions` in the Claude Code workflow (`.github/workflows/claude.yml`) to only `actions: read`, removing the `contents: write`, `pull-requests: write`, and `issues: write` entries added in #98
- These extra permissions caused the GitHub App installation token exchange to fail with `401 Unauthorized`, preventing Claude from responding to `@claude` mentions in issues and PRs

## Root cause

PR #98 added write permissions to `additional_permissions` in the `claude-code-action` configuration. The Claude Code GitHub App installation does not have those write permissions granted, so the token exchange fails when requesting them.

## Test plan

- [ ] Verify the Claude Code workflow passes on this PR
- [ ] Mention `@claude` in an issue or PR comment and confirm it responds
