### PR TITLE
chore: allow RSpec and dev tools in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,13 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(bundle exec rspec:*)",
+      "Bash(bin/rails:*)",
+      "Bash(bin/rubocop:*)",
+      "Bash(bin/brakeman:*)",
+      "Bash(bin/bundler-audit:*)"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
## Summary
- Add `permissions.allow` to `.claude/settings.json` to enable Claude to run RSpec, Rails commands, RuboCop, Brakeman, and bundler-audit
- This allows the Claude GitHub Action to execute `bundle exec rspec` for test verification
