### PR TITLE
fix(specs): replace deprecated :unprocessable_entity with :unprocessable_content

### DIFF
--- a/spec/requests/api/v1/examples_spec.rb
+++ b/spec/requests/api/v1/examples_spec.rb
@@ -74,11 +74,11 @@ RSpec.describe 'Api::V1::Examples', type: :request do
     end
 
     context 'with invalid params' do
-      it 'returns unprocessable_entity' do
+      it 'returns unprocessable_content' do
         post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples",
              params: { example: { sentence: '', translation: '翻訳', display_order: 1 } }, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 

--- a/spec/requests/api/v1/meanings_spec.rb
+++ b/spec/requests/api/v1/meanings_spec.rb
@@ -67,11 +67,11 @@ RSpec.describe 'Api::V1::Meanings', type: :request do
     end
 
     context 'with invalid params' do
-      it 'returns unprocessable_entity' do
+      it 'returns unprocessable_content' do
         post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings",
              params: { meaning: { definition: '', display_order: 1 } }, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Api::V1::Settings', type: :request do
     end
 
     context 'with missing intervals' do
-      it 'returns unprocessable_entity' do
+      it 'returns unprocessable_content' do
         params = {
           setting: {
             hard_interval: { days: 1, hours: 0, minutes: 0 }
@@ -65,12 +65,12 @@ RSpec.describe 'Api::V1::Settings', type: :request do
 
         post '/api/v1/setting', params: params, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
     context 'with intervals not in ascending order' do
-      it 'returns unprocessable_entity with error message' do
+      it 'returns unprocessable_content with error message' do
         params = {
           setting: {
             hard_interval: { days: 5, hours: 0, minutes: 0 },
@@ -81,7 +81,7 @@ RSpec.describe 'Api::V1::Settings', type: :request do
 
         post '/api/v1/setting', params: params, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expected_message = 'intervals must be in ascending order: hard < uncertain < easy'
         expect(response.parsed_body['errors']).to include(expected_message)
       end
@@ -103,7 +103,7 @@ RSpec.describe 'Api::V1::Settings', type: :request do
     end
 
     context 'with intervals not in ascending order' do
-      it 'returns unprocessable_entity with error message' do
+      it 'returns unprocessable_content with error message' do
         patch '/api/v1/setting', params: {
           setting: {
             hard_interval: { days: 1, hours: 0, minutes: 0 },
@@ -112,7 +112,7 @@ RSpec.describe 'Api::V1::Settings', type: :request do
           }
         }, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expected_message = 'intervals must be in ascending order: hard < uncertain < easy'
         expect(response.parsed_body['errors']).to include(expected_message)
       end

--- a/spec/requests/api/v1/wordbooks_spec.rb
+++ b/spec/requests/api/v1/wordbooks_spec.rb
@@ -67,10 +67,10 @@ RSpec.describe 'Api::V1::Wordbooks', type: :request do
     end
 
     context 'with invalid params' do
-      it 'returns unprocessable_entity' do
+      it 'returns unprocessable_content' do
         post '/api/v1/wordbooks', params: { wordbook: { title: '' } }, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.parsed_body['errors']).to include("Title can't be blank")
       end
     end
@@ -89,10 +89,10 @@ RSpec.describe 'Api::V1::Wordbooks', type: :request do
     end
 
     context 'with invalid params' do
-      it 'returns unprocessable_entity' do
+      it 'returns unprocessable_content' do
         patch "/api/v1/wordbooks/#{wordbook.id}", params: { wordbook: { title: '' } }, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -142,11 +142,11 @@ RSpec.describe 'Api::V1::Words', type: :request do
     end
 
     context 'with invalid params' do
-      it 'returns unprocessable_entity' do
+      it 'returns unprocessable_content' do
         post "/api/v1/wordbooks/#{wordbook.id}/words", params: { word: { spelling: '', status: 'not_studied' } },
                                                        headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.parsed_body['errors']).to include("Spelling can't be blank")
       end
     end


### PR DESCRIPTION
Replace deprecated `:unprocessable_entity` status symbol with the RFC 9110 compliant `:unprocessable_content` in all request specs. Rack 3.x emits deprecation warnings for the old symbol, and Rails 7.1+ has added `:unprocessable_content` as the canonical name for HTTP 422.

Also updates `it` description strings to match the new status name for consistency.

Closes #102

Generated with [Claude Code](https://claude.ai/code)