### PR TITLE
test: use guaranteed non-existent ID (0) in RecordNotFound spec

### DIFF
--- a/spec/requests/error_handling_spec.rb
+++ b/spec/requests/error_handling_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Error handling', type: :request do
 
   describe 'ActiveRecord::RecordNotFound' do
     it 'returns not_found for nonexistent resource' do
-      get '/api/v1/wordbooks/999999', headers: headers
+      get '/api/v1/wordbooks/0', headers: headers
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body['error']).to eq('Not found')


### PR DESCRIPTION
Replace hardcoded ID `999999` with `0` in error_handling_spec.rb.
PostgreSQL auto-increment IDs start at 1, so 0 is guaranteed to never exist, making the test more robust.

Closes #105

Generated with [Claude Code](https://claude.ai/code)