### PR TITLE
Fix: normalize CHECK constraint syntax in schema.rb for PostgreSQL 17

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,7 +58,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_121300) do
     t.index ["provider", "provider_uid"], name: "index_users_on_provider_and_provider_uid", unique: true
     t.check_constraint "provider::text <> 'guest'::text OR guest_expires_at IS NOT NULL", name: "check_guest_expires_at_presence"
     t.check_constraint "provider::text = 'guest'::text OR provider_uid IS NOT NULL", name: "chk_provider_uid_required_for_non_guest"
-    t.check_constraint "provider::text = ANY (ARRAY['google'::character varying::text, 'guest'::character varying::text])", name: "check_users_provider_values"
+    t.check_constraint "provider::text = ANY (ARRAY['google'::character varying, 'guest'::character varying]::text[])", name: "check_users_provider_values"
   end
 
   create_table "wordbooks", force: :cascade do |t|
@@ -77,7 +77,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_121300) do
     t.datetime "updated_at", null: false
     t.bigint "wordbook_id", null: false
     t.index ["wordbook_id"], name: "index_words_on_wordbook_id"
-    t.check_constraint "status::text = ANY (ARRAY['not_studied'::character varying::text, 'hard'::character varying::text, 'uncertain'::character varying::text, 'easy'::character varying::text])", name: "check_words_status_values"
+    t.check_constraint "status::text = ANY (ARRAY['not_studied'::character varying, 'hard'::character varying, 'uncertain'::character varying, 'easy'::character varying]::text[])", name: "check_words_status_values"
   end
 
   add_foreign_key "examples", "words"


### PR DESCRIPTION
## Summary
- Re-dump `db/schema.rb` with local PostgreSQL 17.7 to normalize CHECK constraint cast syntax
- Affects `users.check_users_provider_values` and `words.check_words_status_values` constraints
- No functional change — only the SQL text representation differs (`::character varying::text` per-element → `::character varying` per-element with `::text[]` on the array)

## Background
Commit db8cea1 was generated in a CI environment whose PostgreSQL 17 patch version produced a slightly different `pg_get_constraintdef()` output. This PR aligns `schema.rb` with the format produced by PostgreSQL 17.7 (used locally and in CI `postgres:17` image) to prevent future format drift.

## Test plan
- [x] Verified `bin/rails db:schema:dump` produces no additional diff after this change
- [ ] CI passes (no migration or schema issues)