### PR TITLE
feat: add logging for non-500 error responses

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -11,19 +11,30 @@ class ErrorsController < ActionController::API
 
     case status
     when 400
+      log_client_error(status)
       exception&.message || 'Bad request'
     when 401
+      log_client_error(status)
       exception.is_a?(GoogleIdToken::VerificationError) ? 'Invalid ID token' : 'Unauthorized'
     when 404
+      log_client_error(status)
       'Not found'
     when 409
+      log_client_error(status)
       'Duplicate record'
     when 500
       log_server_error(exception) if exception
       'Internal server error'
     else
+      log_server_error(exception) if status >= 500 && exception
       Rack::Utils::HTTP_STATUS_CODES.fetch(status, 'Unknown error')
     end
+  end
+
+  def log_client_error(status)
+    original_method = request.env['action_dispatch.original_request_method'] || request.method
+    original_path = request.env['action_dispatch.original_path'] || request.path
+    Rails.logger.warn("Client error: #{status} #{original_method} #{original_path}")
   end
 
   def log_server_error(exception)

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -17,4 +17,42 @@ RSpec.describe 'Errors', type: :request do
       expect(response.parsed_body['error']).to eq('Not found')
     end
   end
+
+  describe 'logging' do
+    describe '4xx errors' do
+      it 'logs a warning for 404 errors' do
+        allow(Rails.logger).to receive(:warn)
+
+        get '/nonexistent/path'
+
+        expect(Rails.logger).to have_received(:warn).with('Client error: 404 GET /nonexistent/path')
+      end
+    end
+
+    describe '5xx errors' do
+      let(:exception) { StandardError.new('something went wrong') }
+
+      before do
+        exception.set_backtrace(Array.new(15) { |i| "app/models/foo.rb:#{i + 1}" })
+      end
+
+      it 'logs error with backtrace for 500 errors' do
+        allow(Rails.logger).to receive(:error)
+
+        get '/500', env: { 'action_dispatch.exception' => exception }
+
+        expect(Rails.logger).to have_received(:error).with('Unhandled error: StandardError - something went wrong')
+        expect(Rails.logger).to have_received(:error).with(exception.backtrace.first(10).join("\n"))
+      end
+
+      it 'logs error with backtrace for non-500 5xx errors' do
+        allow(Rails.logger).to receive(:error)
+
+        get '/502', env: { 'action_dispatch.exception' => exception }
+
+        expect(Rails.logger).to have_received(:error).with('Unhandled error: StandardError - something went wrong')
+        expect(Rails.logger).to have_received(:error).with(exception.backtrace.first(10).join("\n"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add warn-level logging for 4xx errors with original request method and path
- Add error-level logging with backtrace for non-500 5xx errors, consistent with existing 500 handling

Closes #103