### PR TITLE
refactor: centralize error responses through ErrorsController

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -14,7 +14,7 @@ module Api
       def google
         id_token = request.headers['Authorization']&.split('Bearer ')&.last
 
-        return render json: { error: 'Authorization header missing' }, status: :bad_request if id_token.blank?
+        raise BadRequestError, 'Authorization header missing' if id_token.blank?
 
         payload = GoogleIdToken.decode(id_token)
 
@@ -24,9 +24,8 @@ module Api
         existing_user = User.find_by(email: email) if email.present?
 
         if existing_user && existing_user.provider != 'google'
-          message = "This email is already registered with #{existing_user.provider}. " \
-                    "Please sign in with #{existing_user.provider}."
-          return render json: { error: message }, status: :conflict
+          raise ConflictError, "This email is already registered with #{existing_user.provider}. " \
+                               "Please sign in with #{existing_user.provider}."
         end
 
         user = User.find_or_create_by(provider: 'google', provider_uid: payload['sub']) do |u|
@@ -44,18 +43,14 @@ module Api
 
       def handle_guest_migration(google_payload)
         guest_user = User.find_by_token(params[:guest_token])
-
-        return render json: { error: 'Invalid guest token' }, status: :unauthorized unless guest_user&.guest?
+        raise AuthenticationError, 'Invalid guest token' unless guest_user&.guest?
 
         result = guest_user.migrate_to_google(google_payload)
+        raise UnprocessableEntityError, result.error unless result.success?
 
-        if result.success?
-          user_json = JSON.parse(UserResource.new(result.user, params: { type: :google }).serialize)
-          render json: { user: user_json, token: JsonWebToken.encode(result.user.id) },
-                 status: :ok
-        else
-          render json: { error: result.error }, status: :unprocessable_content
-        end
+        user_json = JSON.parse(UserResource.new(result.user, params: { type: :google }).serialize)
+        render json: { user: user_json, token: JsonWebToken.encode(result.user.id) },
+               status: :ok
       end
     end
   end

--- a/app/controllers/api/v1/examples_controller.rb
+++ b/app/controllers/api/v1/examples_controller.rb
@@ -15,20 +15,13 @@ module Api
 
       def create
         example = @word.examples.new(example_params)
-
-        if example.save
-          render json: ExampleResource.new(example).serialize, status: :created
-        else
-          render json: { errors: example.errors.full_messages }, status: :unprocessable_content
-        end
+        example.save!
+        render json: ExampleResource.new(example).serialize, status: :created
       end
 
       def update
-        if @example.update(example_params)
-          render json: ExampleResource.new(@example).serialize
-        else
-          render json: { errors: @example.errors.full_messages }, status: :unprocessable_content
-        end
+        @example.update!(example_params)
+        render json: ExampleResource.new(@example).serialize
       end
 
       def destroy

--- a/app/controllers/api/v1/meanings_controller.rb
+++ b/app/controllers/api/v1/meanings_controller.rb
@@ -15,20 +15,13 @@ module Api
 
       def create
         meaning = @word.meanings.new(meaning_params)
-
-        if meaning.save
-          render json: MeaningResource.new(meaning).serialize, status: :created
-        else
-          render json: { errors: meaning.errors.full_messages }, status: :unprocessable_content
-        end
+        meaning.save!
+        render json: MeaningResource.new(meaning).serialize, status: :created
       end
 
       def update
-        if @meaning.update(meaning_params)
-          render json: MeaningResource.new(@meaning).serialize
-        else
-          render json: { errors: @meaning.errors.full_messages }, status: :unprocessable_content
-        end
+        @meaning.update!(meaning_params)
+        render json: MeaningResource.new(@meaning).serialize
       end
 
       def destroy

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -9,20 +9,13 @@ module Api
 
       def create
         setting = current_user.build_setting(build_setting_params)
-
-        if setting.save
-          render json: SettingResource.new(setting).serialize, status: :created
-        else
-          render json: { errors: setting.errors.full_messages }, status: :unprocessable_content
-        end
+        setting.save!
+        render json: SettingResource.new(setting).serialize, status: :created
       end
 
       def update
-        if @setting.update(build_setting_params)
-          render json: SettingResource.new(@setting).serialize
-        else
-          render json: { errors: @setting.errors.full_messages }, status: :unprocessable_content
-        end
+        @setting.update!(build_setting_params)
+        render json: SettingResource.new(@setting).serialize
       end
 
       def destroy

--- a/app/controllers/api/v1/wordbooks_controller.rb
+++ b/app/controllers/api/v1/wordbooks_controller.rb
@@ -14,20 +14,13 @@ module Api
 
       def create
         wordbook = current_user.wordbooks.new(wordbook_params)
-
-        if wordbook.save
-          render json: WordbookResource.new(wordbook).serialize, status: :created
-        else
-          render json: { errors: wordbook.errors.full_messages }, status: :unprocessable_content
-        end
+        wordbook.save!
+        render json: WordbookResource.new(wordbook).serialize, status: :created
       end
 
       def update
-        if @wordbook.update(wordbook_params)
-          render json: WordbookResource.new(@wordbook).serialize
-        else
-          render json: { errors: @wordbook.errors.full_messages }, status: :unprocessable_content
-        end
+        @wordbook.update!(wordbook_params)
+        render json: WordbookResource.new(@wordbook).serialize
       end
 
       def destroy

--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -17,20 +17,13 @@ module Api
 
       def create
         word = @wordbook.words.new(word_params)
-
-        if word.save
-          render json: WordResource.new(word).serialize, status: :created
-        else
-          render json: { errors: word.errors.full_messages }, status: :unprocessable_content
-        end
+        word.save!
+        render json: WordResource.new(word).serialize, status: :created
       end
 
       def update
-        if @word.update(word_params)
-          render json: WordResource.new(@word).serialize
-        else
-          render json: { errors: @word.errors.full_messages }, status: :unprocessable_content
-        end
+        @word.update!(word_params)
+        render json: WordResource.new(@word).serialize
       end
 
       def destroy

--- a/app/controllers/concerns/authenticatable.rb
+++ b/app/controllers/concerns/authenticatable.rb
@@ -9,17 +9,13 @@ module Authenticatable
 
   def authenticate_user!
     token = request.headers['Authorization']&.split('Bearer ')&.last
-    return render_unauthorized unless token
+    raise AuthenticationError unless token
 
     @current_user = User.find_by_token(token)
-    render_unauthorized unless @current_user
+    raise AuthenticationError unless @current_user
   end
 
   def current_user
     @current_user
-  end
-
-  def render_unauthorized
-    render json: { error: 'Unauthorized' }, status: :unauthorized
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -11,17 +11,20 @@ class ErrorsController < ActionController::API
 
     case status
     when 400
-      log_client_error(status)
-      exception&.message || 'Bad request'
+      log_client_error(status, exception)
+      'Bad request'
     when 401
-      log_client_error(status)
-      exception.is_a?(GoogleIdToken::VerificationError) ? 'Invalid ID token' : 'Unauthorized'
+      log_client_error(status, exception)
+      'Unauthorized'
     when 404
-      log_client_error(status)
+      log_client_error(status, exception)
       'Not found'
     when 409
-      log_client_error(status)
+      log_client_error(status, exception)
       'Duplicate record'
+    when 422
+      log_client_error(status, exception)
+      'Unprocessable entity'
     when 500
       log_server_error(exception) if exception
       'Internal server error'
@@ -31,10 +34,12 @@ class ErrorsController < ActionController::API
     end
   end
 
-  def log_client_error(status)
+  def log_client_error(status, exception = nil)
     original_method = request.env['action_dispatch.original_request_method'] || request.method
     original_path = request.env['action_dispatch.original_path'] || request.path
-    Rails.logger.warn("Client error: #{status} #{original_method} #{original_path}")
+    message = "Client error: #{status} #{original_method} #{original_path}"
+    message += " - #{exception.class}: #{exception.message}" if exception
+    Rails.logger.warn(message)
   end
 
   def log_server_error(exception)

--- a/app/errors/application_error.rb
+++ b/app/errors/application_error.rb
@@ -1,0 +1,1 @@
+class ApplicationError < StandardError; end

--- a/app/errors/authentication_error.rb
+++ b/app/errors/authentication_error.rb
@@ -1,0 +1,1 @@
+class AuthenticationError < ApplicationError; end

--- a/app/errors/bad_request_error.rb
+++ b/app/errors/bad_request_error.rb
@@ -1,0 +1,1 @@
+class BadRequestError < ApplicationError; end

--- a/app/errors/conflict_error.rb
+++ b/app/errors/conflict_error.rb
@@ -1,0 +1,1 @@
+class ConflictError < ApplicationError; end

--- a/app/errors/unprocessable_entity_error.rb
+++ b/app/errors/unprocessable_entity_error.rb
@@ -1,0 +1,1 @@
+class UnprocessableEntityError < ApplicationError; end

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,11 @@ module WordbeetleApi
 
     config.action_dispatch.rescue_responses.merge!(
       'ActiveRecord::RecordNotUnique' => :conflict,
-      'GoogleIdToken::VerificationError' => :unauthorized
+      'GoogleIdToken::VerificationError' => :unauthorized,
+      'AuthenticationError' => :unauthorized,
+      'BadRequestError' => :bad_request,
+      'ConflictError' => :conflict,
+      'UnprocessableEntityError' => :unprocessable_entity
     )
   end
 end

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Api::V1::Auth', type: :request do
         post '/api/v1/auth/google'
 
         expect(response).to have_http_status(:bad_request)
-        expect(response.parsed_body['error']).to eq('Authorization header missing')
+        expect(response.parsed_body['error']).to eq('Bad request')
       end
     end
 
@@ -75,7 +75,7 @@ RSpec.describe 'Api::V1::Auth', type: :request do
         post '/api/v1/auth/google', headers: { 'Authorization' => 'Bearer invalid_token' }
 
         expect(response).to have_http_status(:unauthorized)
-        expect(response.parsed_body['error']).to eq('Invalid ID token')
+        expect(response.parsed_body['error']).to eq('Unauthorized')
       end
     end
 
@@ -144,7 +144,7 @@ RSpec.describe 'Api::V1::Auth', type: :request do
         post '/api/v1/auth/google', headers: { 'Authorization' => 'Bearer valid_token' }
 
         expect(response).to have_http_status(:conflict)
-        expect(response.parsed_body['error']).to include('already registered')
+        expect(response.parsed_body['error']).to eq('Duplicate record')
       end
     end
 
@@ -285,7 +285,7 @@ RSpec.describe 'Api::V1::Auth', type: :request do
                headers: { 'Authorization' => 'Bearer valid_token' }
 
           expect(response).to have_http_status(:unauthorized)
-          expect(response.parsed_body['error']).to eq('Invalid guest token')
+          expect(response.parsed_body['error']).to eq('Unauthorized')
         end
       end
 
@@ -301,7 +301,7 @@ RSpec.describe 'Api::V1::Auth', type: :request do
                headers: { 'Authorization' => 'Bearer valid_token' }
 
           expect(response).to have_http_status(:unauthorized)
-          expect(response.parsed_body['error']).to eq('Invalid guest token')
+          expect(response.parsed_body['error']).to eq('Unauthorized')
         end
       end
     end

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -82,8 +82,7 @@ RSpec.describe 'Api::V1::Settings', type: :request do
         post '/api/v1/setting', params: params, headers: headers
 
         expect(response).to have_http_status(:unprocessable_content)
-        expected_message = 'intervals must be in ascending order: hard < uncertain < easy'
-        expect(response.parsed_body['errors']).to include(expected_message)
+        expect(response.parsed_body['error']).to eq('Unprocessable entity')
       end
     end
   end
@@ -113,8 +112,7 @@ RSpec.describe 'Api::V1::Settings', type: :request do
         }, headers: headers
 
         expect(response).to have_http_status(:unprocessable_content)
-        expected_message = 'intervals must be in ascending order: hard < uncertain < easy'
-        expect(response.parsed_body['errors']).to include(expected_message)
+        expect(response.parsed_body['error']).to eq('Unprocessable entity')
       end
     end
   end

--- a/spec/requests/api/v1/wordbooks_spec.rb
+++ b/spec/requests/api/v1/wordbooks_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Api::V1::Wordbooks', type: :request do
         post '/api/v1/wordbooks', params: { wordbook: { title: '' } }, headers: headers
 
         expect(response).to have_http_status(:unprocessable_content)
-        expect(response.parsed_body['errors']).to include("Title can't be blank")
+        expect(response.parsed_body['error']).to eq('Unprocessable entity')
       end
     end
   end

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
                                                        headers: headers
 
         expect(response).to have_http_status(:unprocessable_content)
-        expect(response.parsed_body['errors']).to include("Spelling can't be blank")
+        expect(response.parsed_body['error']).to eq('Unprocessable entity')
       end
     end
 

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -20,12 +20,27 @@ RSpec.describe 'Errors', type: :request do
 
   describe 'logging' do
     describe '4xx errors' do
-      it 'logs a warning for 404 errors' do
+      it 'logs a warning with exception details for 404 errors' do
         allow(Rails.logger).to receive(:warn)
 
         get '/nonexistent/path'
 
-        expect(Rails.logger).to have_received(:warn).with('Client error: 404 GET /nonexistent/path')
+        expect(Rails.logger).to have_received(:warn).with(
+          a_string_starting_with('Client error: 404 GET /nonexistent/path - ')
+        )
+      end
+
+      it 'logs a warning with exception details for 422 errors' do
+        exception = ActiveRecord::RecordInvalid.new
+        allow(Rails.logger).to receive(:warn)
+
+        get '/422', env: { 'action_dispatch.exception' => exception }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to eq('Unprocessable entity')
+        expect(Rails.logger).to have_received(:warn).with(
+          a_string_matching(%r{Client error: 422 GET /422 - ActiveRecord::RecordInvalid:})
+        )
       end
     end
 


### PR DESCRIPTION
## Summary
- Define custom exception classes (AuthenticationError, BadRequestError, ConflictError, UnprocessableEntityError) and register them in rescue_responses
- Update ErrorsController to return only generic error messages and log exception details server-side
- Replace all direct error renders in controllers with raised exceptions, using save!/update! for validation errors

Closes #108