### PR TITLE
fix: rescue RecordNotUnique in google auth and retry find

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -28,10 +28,17 @@ module Api
                                "Please sign in with #{existing_user.provider}."
         end
 
-        user = User.find_or_create_by(provider: 'google', provider_uid: payload['sub']) do |u|
-          u.email = email
-          u.name = payload['name']
-          u.avatar_url = payload['picture']
+        begin
+          user = User.find_or_create_by(provider: 'google', provider_uid: payload['sub']) do |u|
+            u.email = email
+            u.name = payload['name']
+            u.avatar_url = payload['picture']
+          end
+        rescue ActiveRecord::RecordNotUnique
+          Rails.logger.warn(
+            "Google auth race condition: RecordNotUnique for provider_uid=#{payload['sub']}, retrying find"
+          )
+          user = User.find_by!(provider: 'google', provider_uid: payload['sub'])
         end
 
         render json: { user: JSON.parse(UserResource.new(user, params: { type: :google }).serialize),

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -134,6 +134,32 @@ RSpec.describe 'Api::V1::Auth', type: :request do
       end
     end
 
+    context 'when RecordNotUnique is raised (race condition)' do
+      let!(:existing_user) do
+        create(:user, provider: 'google', provider_uid: 'google_uid_123', email: 'test@example.com')
+      end
+
+      before do
+        allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return(google_payload)
+        allow(User).to receive(:find_or_create_by).and_raise(ActiveRecord::RecordNotUnique)
+      end
+
+      it 'retries and returns the existing user' do
+        expect do
+          post '/api/v1/auth/google', headers: { 'Authorization' => 'Bearer valid_token' }
+        end.not_to change(User, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['token']).to be_present
+      end
+
+      it 'logs a warning with provider_uid' do
+        allow(Rails.logger).to receive(:warn)
+        post '/api/v1/auth/google', headers: { 'Authorization' => 'Bearer valid_token' }
+        expect(Rails.logger).to have_received(:warn).with(/provider_uid=google_uid_123/)
+      end
+    end
+
     context 'when email is already registered with a different provider' do
       before do
         allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return(google_payload)


### PR DESCRIPTION
close #115

## Changes

- Wrap `find_or_create_by` in `AuthController#google` with rescue for `ActiveRecord::RecordNotUnique`
- On race condition, emit a warn-level log with `provider_uid` and retry with `find_by!`
- Tests cover retry behavior and warning log

Generated with [Claude Code](https://claude.ai/code)