### PR TITLE
feat: implement pagination for list endpoints (#114)

### DIFF
--- a/app/controllers/api/v1/examples_controller.rb
+++ b/app/controllers/api/v1/examples_controller.rb
@@ -5,8 +5,8 @@ module Api
       before_action :set_example, only: %i[show update destroy]
 
       def index
-        examples = @word.examples
-        render json: ExampleResource.new(examples).serialize
+        records, meta = paginate(@word.examples)
+        render json: { data: JSON.parse(ExampleResource.new(records).serialize), pagination: meta }
       end
 
       def show

--- a/app/controllers/api/v1/meanings_controller.rb
+++ b/app/controllers/api/v1/meanings_controller.rb
@@ -5,8 +5,8 @@ module Api
       before_action :set_meaning, only: %i[show update destroy]
 
       def index
-        meanings = @word.meanings
-        render json: MeaningResource.new(meanings).serialize
+        records, meta = paginate(@word.meanings)
+        render json: { data: JSON.parse(MeaningResource.new(records).serialize), pagination: meta }
       end
 
       def show

--- a/app/controllers/api/v1/wordbooks_controller.rb
+++ b/app/controllers/api/v1/wordbooks_controller.rb
@@ -4,8 +4,8 @@ module Api
       before_action :set_wordbook, only: %i[show update destroy]
 
       def index
-        wordbooks = current_user.wordbooks
-        render json: WordbookResource.new(wordbooks).serialize
+        records, meta = paginate(current_user.wordbooks)
+        render json: { data: JSON.parse(WordbookResource.new(records).serialize), pagination: meta }
       end
 
       def show

--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -5,8 +5,11 @@ module Api
       before_action :set_word, only: %i[show update destroy]
 
       def index
-        words = @wordbook.words.includes(:first_meaning)
-        render json: WordResource.new(words, params: { include_first_meaning: true }).serialize
+        records, meta = paginate(@wordbook.words.includes(:first_meaning))
+        render json: {
+          data: JSON.parse(WordResource.new(records, params: { include_first_meaning: true }).serialize),
+          pagination: meta
+        }
       end
 
       def show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::API
   include Authenticatable
+  include Paginatable
 end

--- a/app/controllers/concerns/paginatable.rb
+++ b/app/controllers/concerns/paginatable.rb
@@ -1,0 +1,35 @@
+module Paginatable
+  extend ActiveSupport::Concern
+
+  DEFAULT_PER_PAGE = 25
+  MAX_PER_PAGE = 100
+  private_constant :DEFAULT_PER_PAGE, :MAX_PER_PAGE
+
+  private
+
+  def paginate(collection)
+    per = per_page_param
+    total_count = collection.count
+    total_pages = [(total_count.to_f / per).ceil, 1].max
+    current_page = page_param.clamp(1, total_pages)
+
+    records = collection.offset((current_page - 1) * per).limit(per)
+    meta = {
+      current_page: current_page,
+      total_pages: total_pages,
+      total_count: total_count,
+      per_page: per
+    }
+    [records, meta]
+  end
+
+  def page_param
+    val = params[:page].to_i
+    val.positive? ? val : 1
+  end
+
+  def per_page_param
+    val = params[:per_page].to_i
+    val.positive? && val <= MAX_PER_PAGE ? val : DEFAULT_PER_PAGE
+  end
+end

--- a/spec/requests/api/v1/examples_spec.rb
+++ b/spec/requests/api/v1/examples_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Api::V1::Examples', type: :request do
       get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body.size).to eq(2)
+      expect(response.parsed_body['data'].size).to eq(2)
     end
 
     it 'returns 401 without authentication' do
@@ -30,6 +30,49 @@ RSpec.describe 'Api::V1::Examples', type: :request do
       get "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples", headers: headers
 
       expect(response).to have_http_status(:not_found)
+    end
+
+    describe 'pagination' do
+      it 'returns pagination metadata' do
+        create_list(:example, 2, word: word)
+
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples", headers: headers
+
+        pagination = response.parsed_body['pagination']
+        expect(pagination['current_page']).to eq(1)
+        expect(pagination['total_count']).to eq(2)
+        expect(pagination['per_page']).to eq(25)
+        expect(pagination['total_pages']).to eq(1)
+      end
+
+      it 'supports per_page parameter' do
+        create_list(:example, 3, word: word)
+
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples", params: { per_page: 2 }, headers: headers
+
+        expect(response.parsed_body['data'].size).to eq(2)
+        expect(response.parsed_body['pagination']['total_pages']).to eq(2)
+      end
+
+      it 'supports page parameter' do
+        create_list(:example, 3, word: word)
+
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples",
+            params: { per_page: 2, page: 2 }, headers: headers
+
+        expect(response.parsed_body['data'].size).to eq(1)
+        expect(response.parsed_body['pagination']['current_page']).to eq(2)
+      end
+
+      it 'clamps out-of-range page to last page' do
+        create_list(:example, 2, word: word)
+
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples",
+            params: { page: 999 }, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['pagination']['current_page']).to eq(1)
+      end
     end
   end
 

--- a/spec/requests/api/v1/meanings_spec.rb
+++ b/spec/requests/api/v1/meanings_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Api::V1::Meanings', type: :request do
       get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body.size).to eq(2)
+      expect(response.parsed_body['data'].size).to eq(2)
     end
 
     it 'returns 401 without authentication' do
@@ -30,6 +30,49 @@ RSpec.describe 'Api::V1::Meanings', type: :request do
       get "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings", headers: headers
 
       expect(response).to have_http_status(:not_found)
+    end
+
+    describe 'pagination' do
+      it 'returns pagination metadata' do
+        create_list(:meaning, 2, word: word)
+
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings", headers: headers
+
+        pagination = response.parsed_body['pagination']
+        expect(pagination['current_page']).to eq(1)
+        expect(pagination['total_count']).to eq(2)
+        expect(pagination['per_page']).to eq(25)
+        expect(pagination['total_pages']).to eq(1)
+      end
+
+      it 'supports per_page parameter' do
+        create_list(:meaning, 3, word: word)
+
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings", params: { per_page: 2 }, headers: headers
+
+        expect(response.parsed_body['data'].size).to eq(2)
+        expect(response.parsed_body['pagination']['total_pages']).to eq(2)
+      end
+
+      it 'supports page parameter' do
+        create_list(:meaning, 3, word: word)
+
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings",
+            params: { per_page: 2, page: 2 }, headers: headers
+
+        expect(response.parsed_body['data'].size).to eq(1)
+        expect(response.parsed_body['pagination']['current_page']).to eq(2)
+      end
+
+      it 'clamps out-of-range page to last page' do
+        create_list(:meaning, 2, word: word)
+
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings",
+            params: { page: 999 }, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['pagination']['current_page']).to eq(1)
+      end
     end
   end
 

--- a/spec/requests/api/v1/wordbooks_spec.rb
+++ b/spec/requests/api/v1/wordbooks_spec.rb
@@ -12,20 +12,61 @@ RSpec.describe 'Api::V1::Wordbooks', type: :request do
       get '/api/v1/wordbooks', headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body.size).to eq(3)
+      expect(response.parsed_body['data'].size).to eq(3)
     end
 
     it 'returns empty array when no wordbooks exist' do
       get '/api/v1/wordbooks', headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to eq([])
+      expect(response.parsed_body['data']).to eq([])
     end
 
     it 'returns 401 without authentication' do
       get '/api/v1/wordbooks'
 
       expect(response).to have_http_status(:unauthorized)
+    end
+
+    describe 'pagination' do
+      it 'returns pagination metadata' do
+        create_list(:wordbook, 3, user: user)
+
+        get '/api/v1/wordbooks', headers: headers
+
+        pagination = response.parsed_body['pagination']
+        expect(pagination['current_page']).to eq(1)
+        expect(pagination['total_count']).to eq(3)
+        expect(pagination['per_page']).to eq(25)
+        expect(pagination['total_pages']).to eq(1)
+      end
+
+      it 'supports per_page parameter' do
+        create_list(:wordbook, 3, user: user)
+
+        get '/api/v1/wordbooks', params: { per_page: 2 }, headers: headers
+
+        expect(response.parsed_body['data'].size).to eq(2)
+        expect(response.parsed_body['pagination']['total_pages']).to eq(2)
+      end
+
+      it 'supports page parameter' do
+        create_list(:wordbook, 3, user: user)
+
+        get '/api/v1/wordbooks', params: { per_page: 2, page: 2 }, headers: headers
+
+        expect(response.parsed_body['data'].size).to eq(1)
+        expect(response.parsed_body['pagination']['current_page']).to eq(2)
+      end
+
+      it 'clamps out-of-range page to last page' do
+        create_list(:wordbook, 2, user: user)
+
+        get '/api/v1/wordbooks', params: { page: 999 }, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['pagination']['current_page']).to eq(1)
+      end
     end
   end
 

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
       get "/api/v1/wordbooks/#{wordbook.id}/words", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body.size).to eq(3)
+      expect(response.parsed_body['data'].size).to eq(3)
     end
 
     it 'includes first_meaning for each word' do
@@ -23,7 +23,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
 
       get "/api/v1/wordbooks/#{wordbook.id}/words", headers: headers
 
-      returned_word = response.parsed_body.find { |w| w['id'] == word.id }
+      returned_word = response.parsed_body['data'].find { |w| w['id'] == word.id }
       expect(returned_word['first_meaning']['definition']).to eq('first')
     end
 
@@ -32,7 +32,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
 
       get "/api/v1/wordbooks/#{wordbook.id}/words", headers: headers
 
-      expect(response.parsed_body.first['first_meaning']).to be_nil
+      expect(response.parsed_body['data'].first['first_meaning']).to be_nil
     end
 
     it 'returns 401 without authentication' do
@@ -47,6 +47,47 @@ RSpec.describe 'Api::V1::Words', type: :request do
       get "/api/v1/wordbooks/#{other_wordbook.id}/words", headers: headers
 
       expect(response).to have_http_status(:not_found)
+    end
+
+    describe 'pagination' do
+      it 'returns pagination metadata' do
+        create_list(:word, 3, wordbook: wordbook)
+
+        get "/api/v1/wordbooks/#{wordbook.id}/words", headers: headers
+
+        pagination = response.parsed_body['pagination']
+        expect(pagination['current_page']).to eq(1)
+        expect(pagination['total_count']).to eq(3)
+        expect(pagination['per_page']).to eq(25)
+        expect(pagination['total_pages']).to eq(1)
+      end
+
+      it 'supports per_page parameter' do
+        create_list(:word, 3, wordbook: wordbook)
+
+        get "/api/v1/wordbooks/#{wordbook.id}/words", params: { per_page: 2 }, headers: headers
+
+        expect(response.parsed_body['data'].size).to eq(2)
+        expect(response.parsed_body['pagination']['total_pages']).to eq(2)
+      end
+
+      it 'supports page parameter' do
+        create_list(:word, 3, wordbook: wordbook)
+
+        get "/api/v1/wordbooks/#{wordbook.id}/words", params: { per_page: 2, page: 2 }, headers: headers
+
+        expect(response.parsed_body['data'].size).to eq(1)
+        expect(response.parsed_body['pagination']['current_page']).to eq(2)
+      end
+
+      it 'clamps out-of-range page to last page' do
+        create_list(:word, 2, wordbook: wordbook)
+
+        get "/api/v1/wordbooks/#{wordbook.id}/words", params: { page: 999 }, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['pagination']['current_page']).to eq(1)
+      end
     end
   end
 


### PR DESCRIPTION
Closes #114

## Summary

- Add `Paginatable` concern with pure Rails/Ruby pagination (no external gems)
- Update index actions for wordbooks, words, meanings, examples to return `{ data: [...], pagination: {...} }`
- Support `page` / `per_page` query params (default: 25, max: 100)
- Out-of-range pages clamp to last page
- Update existing tests and add pagination-specific tests

Generated with [Claude Code](https://claude.ai/code)