### PR TITLE
feat: implement pagination for list endpoints with pagy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ gem 'rack-attack'
 # Fast JSON serializer
 gem 'alba'
 
+# Fast, lightweight pagination
+gem 'pagy'
+
 # Google authentication library for ID token verification
 gem 'googleauth'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,10 @@ GEM
     openssl (4.0.0)
     os (1.1.4)
     ostruct (0.6.3)
+    pagy (43.5.1)
+      json
+      uri
+      yaml
     parallel (1.27.0)
     parser (3.3.10.1)
       ast (~> 2.4.1)
@@ -378,6 +382,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    yaml (0.4.0)
     zeitwerk (2.7.5)
 
 PLATFORMS
@@ -404,6 +409,7 @@ DEPENDENCIES
   jwt
   kamal
   openssl
+  pagy
   pg (~> 1.1)
   puma (>= 5.0)
   rack-attack

--- a/app/controllers/api/v1/examples_controller.rb
+++ b/app/controllers/api/v1/examples_controller.rb
@@ -6,7 +6,7 @@ module Api
 
       def index
         examples = @word.examples
-        render json: ExampleResource.new(examples).serialize
+        render_paginated(examples, ExampleResource)
       end
 
       def show

--- a/app/controllers/api/v1/meanings_controller.rb
+++ b/app/controllers/api/v1/meanings_controller.rb
@@ -6,7 +6,7 @@ module Api
 
       def index
         meanings = @word.meanings
-        render json: MeaningResource.new(meanings).serialize
+        render_paginated(meanings, MeaningResource)
       end
 
       def show

--- a/app/controllers/api/v1/wordbooks_controller.rb
+++ b/app/controllers/api/v1/wordbooks_controller.rb
@@ -5,7 +5,7 @@ module Api
 
       def index
         wordbooks = current_user.wordbooks
-        render json: WordbookResource.new(wordbooks).serialize
+        render_paginated(wordbooks, WordbookResource)
       end
 
       def show

--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -6,7 +6,7 @@ module Api
 
       def index
         words = @wordbook.words.includes(:first_meaning)
-        render json: WordResource.new(words, params: { include_first_meaning: true }).serialize
+        render_paginated(words, WordResource, params: { include_first_meaning: true })
       end
 
       def show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::API
   include Authenticatable
+  include Paginatable
 end

--- a/app/controllers/concerns/paginatable.rb
+++ b/app/controllers/concerns/paginatable.rb
@@ -1,0 +1,23 @@
+module Paginatable
+  extend ActiveSupport::Concern
+
+  included do
+    include Pagy::Backend
+  end
+
+  private
+
+  def render_paginated(collection, resource_class, status: :ok, **resource_options)
+    pagy_obj, records = pagy(collection)
+
+    render json: {
+      data: resource_class.new(records, **resource_options).serializable_hash,
+      pagination: {
+        current_page: pagy_obj.page,
+        total_pages: pagy_obj.pages,
+        total_count: pagy_obj.count,
+        per_page: pagy_obj.vars[:items]
+      }
+    }, status: status
+  end
+end

--- a/app/controllers/concerns/paginatable.rb
+++ b/app/controllers/concerns/paginatable.rb
@@ -2,13 +2,13 @@ module Paginatable
   extend ActiveSupport::Concern
 
   included do
-    include Pagy::Backend
+    include Pagy::Method
   end
 
   private
 
   def render_paginated(collection, resource_class, status: :ok, **resource_options)
-    pagy_obj, records = pagy(collection)
+    pagy_obj, records = pagy(:offset, collection)
 
     render json: {
       data: resource_class.new(records, **resource_options).serializable_hash,
@@ -16,7 +16,7 @@ module Paginatable
         current_page: pagy_obj.page,
         total_pages: pagy_obj.pages,
         total_count: pagy_obj.count,
-        per_page: pagy_obj.vars[:items]
+        per_page: pagy_obj.limit
       }
     }, status: status
   end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,7 @@
+require 'pagy/extras/items'
+require 'pagy/extras/overflow'
+
+Pagy::DEFAULT[:items] = 20
+Pagy::DEFAULT[:max_items] = 100
+Pagy::DEFAULT[:items_param] = :per_page
+Pagy::DEFAULT[:overflow] = :empty_page

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,7 +1,3 @@
-require 'pagy/extras/items'
-require 'pagy/extras/overflow'
-
-Pagy::DEFAULT[:items] = 20
-Pagy::DEFAULT[:max_items] = 100
-Pagy::DEFAULT[:items_param] = :per_page
-Pagy::DEFAULT[:overflow] = :empty_page
+Pagy::OPTIONS[:limit] = 20
+Pagy::OPTIONS[:max_limit] = 100
+Pagy::OPTIONS[:limit_key] = 'per_page'

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -113,15 +113,23 @@ paths:
       summary: List current user's wordbooks
       security:
         - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PerPage"
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Wordbook"
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Wordbook"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
         "401":
           $ref: "#/components/responses/Unauthorized"
     post:
@@ -237,18 +245,26 @@ paths:
     get:
       tags: [Words]
       summary: List words in a wordbook
-      description: Returns all words with their first meaning (by display_order) included.
+      description: Returns words with their first meaning (by display_order) included.
       security:
         - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PerPage"
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/WordWithFirstMeaning"
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/WordWithFirstMeaning"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -419,15 +435,23 @@ paths:
       summary: List meanings for a word
       security:
         - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PerPage"
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Meaning"
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Meaning"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -558,15 +582,23 @@ paths:
       summary: List examples for a word
       security:
         - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PerPage"
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Example"
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Example"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -834,6 +866,25 @@ components:
       required: true
       schema:
         type: integer
+    Page:
+      name: page
+      in: query
+      required: false
+      description: Page number (default 1)
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    PerPage:
+      name: per_page
+      in: query
+      required: false
+      description: Number of items per page (default 20, max 100)
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
 
   responses:
     Unauthorized:
@@ -1071,6 +1122,18 @@ components:
         hours:
           type: integer
         minutes:
+          type: integer
+
+    Pagination:
+      type: object
+      properties:
+        current_page:
+          type: integer
+        total_pages:
+          type: integer
+        total_count:
+          type: integer
+        per_page:
           type: integer
 
     # ──── Error responses ────

--- a/spec/requests/api/v1/examples_spec.rb
+++ b/spec/requests/api/v1/examples_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe 'Api::V1::Examples', type: :request do
   let(:word) { create(:word, wordbook: wordbook) }
 
   describe 'GET /api/v1/wordbooks/:wordbook_id/words/:word_id/examples' do
+    let(:endpoint_path) { "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples" }
+
+    it_behaves_like 'paginated endpoint', :example, -> { { word: word } }
+
     it "returns current user's examples" do
       create_list(:example, 2, word: word)
       create(:example) # another user's example
@@ -14,7 +18,7 @@ RSpec.describe 'Api::V1::Examples', type: :request do
       get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body.size).to eq(2)
+      expect(response.parsed_body['data'].size).to eq(2)
     end
 
     it 'returns 401 without authentication' do

--- a/spec/requests/api/v1/meanings_spec.rb
+++ b/spec/requests/api/v1/meanings_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe 'Api::V1::Meanings', type: :request do
   let(:word) { create(:word, wordbook: wordbook) }
 
   describe 'GET /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings' do
+    let(:endpoint_path) { "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings" }
+
+    it_behaves_like 'paginated endpoint', :meaning, -> { { word: word } }
+
     it "returns current user's meanings" do
       create_list(:meaning, 2, word: word)
       create(:meaning) # another user's meaning
@@ -14,7 +18,7 @@ RSpec.describe 'Api::V1::Meanings', type: :request do
       get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body.size).to eq(2)
+      expect(response.parsed_body['data'].size).to eq(2)
     end
 
     it 'returns 401 without authentication' do

--- a/spec/requests/api/v1/wordbooks_spec.rb
+++ b/spec/requests/api/v1/wordbooks_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe 'Api::V1::Wordbooks', type: :request do
   let(:headers) { auth_headers_for(user) }
 
   describe 'GET /api/v1/wordbooks' do
+    let(:endpoint_path) { '/api/v1/wordbooks' }
+
+    it_behaves_like 'paginated endpoint', :wordbook, -> { { user: user } }
+
     it "returns current user's wordbooks" do
       create_list(:wordbook, 3, user: user)
       create(:wordbook) # another user's wordbook
@@ -12,14 +16,14 @@ RSpec.describe 'Api::V1::Wordbooks', type: :request do
       get '/api/v1/wordbooks', headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body.size).to eq(3)
+      expect(response.parsed_body['data'].size).to eq(3)
     end
 
     it 'returns empty array when no wordbooks exist' do
       get '/api/v1/wordbooks', headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to eq([])
+      expect(response.parsed_body['data']).to eq([])
     end
 
     it 'returns 401 without authentication' do

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe 'Api::V1::Words', type: :request do
   let(:wordbook) { create(:wordbook, user: user) }
 
   describe 'GET /api/v1/wordbooks/:wordbook_id/words' do
+    let(:endpoint_path) { "/api/v1/wordbooks/#{wordbook.id}/words" }
+
+    it_behaves_like 'paginated endpoint', :word, -> { { wordbook: wordbook } }
+
     it "returns current user's words" do
       create_list(:word, 3, wordbook: wordbook)
       create(:word) # another user's word
@@ -13,7 +17,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
       get "/api/v1/wordbooks/#{wordbook.id}/words", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body.size).to eq(3)
+      expect(response.parsed_body['data'].size).to eq(3)
     end
 
     it 'includes first_meaning for each word' do
@@ -23,7 +27,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
 
       get "/api/v1/wordbooks/#{wordbook.id}/words", headers: headers
 
-      returned_word = response.parsed_body.find { |w| w['id'] == word.id }
+      returned_word = response.parsed_body['data'].find { |w| w['id'] == word.id }
       expect(returned_word['first_meaning']['definition']).to eq('first')
     end
 
@@ -32,7 +36,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
 
       get "/api/v1/wordbooks/#{wordbook.id}/words", headers: headers
 
-      expect(response.parsed_body.first['first_meaning']).to be_nil
+      expect(response.parsed_body['data'].first['first_meaning']).to be_nil
     end
 
     it 'returns 401 without authentication' do

--- a/spec/support/shared_examples/pagination.rb
+++ b/spec/support/shared_examples/pagination.rb
@@ -1,0 +1,38 @@
+RSpec.shared_examples 'paginated endpoint' do |factory_name, create_options_proc|
+  describe 'pagination' do
+    it 'returns pagination metadata' do
+      get endpoint_path, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['pagination']).to include(
+        'current_page' => 1,
+        'per_page' => 20,
+        'total_count' => a_kind_of(Integer),
+        'total_pages' => a_kind_of(Integer)
+      )
+    end
+
+    it 'paginates results with page and per_page params' do
+      create_options = create_options_proc ? instance_exec(&create_options_proc) : {}
+      create_list(factory_name, 3, **create_options)
+
+      get endpoint_path, params: { page: 1, per_page: 2 }, headers: headers
+
+      expect(response.parsed_body['data'].size).to eq(2)
+      pagination = response.parsed_body['pagination']
+      expect(pagination['current_page']).to eq(1)
+      expect(pagination['total_pages']).to eq(2)
+      expect(pagination['total_count']).to eq(3)
+    end
+
+    it 'returns the second page' do
+      create_options = create_options_proc ? instance_exec(&create_options_proc) : {}
+      create_list(factory_name, 3, **create_options)
+
+      get endpoint_path, params: { page: 2, per_page: 2 }, headers: headers
+
+      expect(response.parsed_body['data'].size).to eq(1)
+      expect(response.parsed_body['pagination']['current_page']).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `pagy` gem (v43) for offset-based pagination on all list endpoints
- Wrap list responses in `{ data, pagination }` envelope with `current_page`, `total_pages`, `total_count`, `per_page` metadata
- Accept `page` and `per_page` query parameters (default: 20 per page, max: 100)
- Update OpenAPI spec to reflect new response format and query parameters

Closes #114