### PR TITLE
feat: recalculate next_review_at automatically on word status change

### DIFF
--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -1,0 +1,32 @@
+module Reviewable
+  extend ActiveSupport::Concern
+
+  included do
+    before_update :recalculate_next_review_at, if: :status_changed?
+  end
+
+  private
+
+  def recalculate_next_review_at
+    setting = wordbook.user.effective_setting
+
+    if status.to_sym == :not_studied
+      self.next_review_at = nil
+    elsif next_review_at.nil? || status_was.to_sym == :not_studied
+      self.next_review_at = Time.current + interval_for(status, setting)
+    elsif next_review_at <= Time.current
+      # already past (immediately reviewable) — keep as-is
+    else
+      adjustment = interval_for(status, setting) - interval_for(status_was, setting)
+      self.next_review_at = next_review_at + adjustment
+    end
+  end
+
+  def interval_for(status_key, setting)
+    case status_key.to_sym
+    when :hard      then setting.hard_interval
+    when :uncertain then setting.uncertain_interval
+    when :easy      then setting.easy_interval
+    end
+  end
+end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -1,4 +1,6 @@
 class Word < ApplicationRecord
+  include Reviewable
+
   belongs_to :wordbook
   has_many :meanings, dependent: :destroy
   has_many :examples, dependent: :destroy

--- a/spec/models/concerns/reviewable_spec.rb
+++ b/spec/models/concerns/reviewable_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe Reviewable, type: :model do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:user) { create(:user) }
+  let(:wordbook) { create(:wordbook, user: user) }
+
+  describe 'before_update callback' do
+    context 'when status is unchanged' do
+      let(:word) { create(:word, wordbook: wordbook, status: 'easy', next_review_at: 5.days.from_now) }
+
+      it 'does not recalculate next_review_at' do
+        original = word.next_review_at
+        word.update!(spelling: 'changed')
+        expect(word.next_review_at).to be_within(1.second).of(original)
+      end
+    end
+
+    context 'when changing to not_studied' do
+      let(:word) { create(:word, wordbook: wordbook, status: 'easy', next_review_at: 5.days.from_now) }
+
+      it 'sets next_review_at to nil' do
+        word.update!(status: 'not_studied')
+        expect(word.next_review_at).to be_nil
+      end
+    end
+
+    context 'when changing from not_studied to hard (next_review_at is nil)' do
+      let(:word) { create(:word, wordbook: wordbook, status: 'not_studied', next_review_at: nil) }
+
+      it 'sets next_review_at to now + hard_interval' do
+        freeze_time do
+          word.update!(status: 'hard')
+          expect(word.next_review_at).to be_within(1.second).of(1.day.from_now)
+        end
+      end
+    end
+
+    context 'when changing from not_studied to easy (next_review_at is nil)' do
+      let(:word) { create(:word, wordbook: wordbook, status: 'not_studied', next_review_at: nil) }
+
+      it 'sets next_review_at to now + easy_interval' do
+        freeze_time do
+          word.update!(status: 'easy')
+          expect(word.next_review_at).to be_within(1.second).of(7.days.from_now)
+        end
+      end
+    end
+
+    context 'when next_review_at is nil (easy word never reviewed)' do
+      let(:word) { create(:word, wordbook: wordbook, status: 'easy', next_review_at: nil) }
+
+      it 'sets next_review_at to now + new_interval' do
+        freeze_time do
+          word.update!(status: 'hard')
+          expect(word.next_review_at).to be_within(1.second).of(1.day.from_now)
+        end
+      end
+    end
+
+    context 'when next_review_at is in the past (immediately reviewable)' do
+      let(:past_date) { 2.days.ago }
+      let(:word) { create(:word, wordbook: wordbook, status: 'easy', next_review_at: past_date) }
+
+      it 'keeps next_review_at unchanged' do
+        word.update!(status: 'hard')
+        expect(word.reload.next_review_at).to be_within(1.second).of(past_date)
+      end
+    end
+
+    context 'when changing from easy to hard with future next_review_at' do
+      let(:future_date) { 10.days.from_now }
+      let(:word) { create(:word, wordbook: wordbook, status: 'easy', next_review_at: future_date) }
+
+      it 'adjusts next_review_at earlier by the interval difference' do
+        freeze_time do
+          word.update!(status: 'hard')
+          # easy_interval(7d) - hard_interval(1d) = 6d earlier
+          expect(word.next_review_at).to be_within(1.second).of(future_date - 6.days)
+        end
+      end
+    end
+
+    context 'when changing from hard to easy with future next_review_at' do
+      let(:future_date) { 5.days.from_now }
+      let(:word) { create(:word, wordbook: wordbook, status: 'hard', next_review_at: future_date) }
+
+      it 'adjusts next_review_at later by the interval difference' do
+        freeze_time do
+          word.update!(status: 'easy')
+          # hard_interval(1d) - easy_interval(7d) = -6d (later)
+          expect(word.next_review_at).to be_within(1.second).of(future_date + 6.days)
+        end
+      end
+    end
+
+    context 'with custom user settings' do
+      let!(:setting) do
+        create(:setting, user: user, hard_interval: 2.days, uncertain_interval: 4.days, easy_interval: 10.days)
+      end
+      let(:future_date) { 15.days.from_now }
+      let(:word) { create(:word, wordbook: wordbook, status: 'easy', next_review_at: future_date) }
+
+      it 'uses custom intervals for recalculation' do
+        freeze_time do
+          word.update!(status: 'hard')
+          # easy_interval(10d) - hard_interval(2d) = 8d earlier
+          expect(word.next_review_at).to be_within(1.second).of(future_date - 8.days)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Words', type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:user) { create(:user) }
   let(:headers) { auth_headers_for(user) }
   let(:wordbook) { create(:wordbook, user: user) }
@@ -180,6 +182,71 @@ RSpec.describe 'Api::V1::Words', type: :request do
                                                                              headers: headers
 
       expect(response).to have_http_status(:not_found)
+    end
+
+    context 'when status changes' do
+      it 'recalculates next_review_at and returns the updated value' do
+        word = create(:word, wordbook: wordbook, status: 'easy', next_review_at: 10.days.from_now)
+
+        freeze_time do
+          patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}",
+                params: { word: { status: 'hard' } }, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          # easy(7d) → hard(1d): 6 days earlier
+          expected = 10.days.from_now - 6.days
+          expect(Time.zone.parse(response.parsed_body['next_review_at'])).to be_within(1.second).of(expected)
+        end
+      end
+
+      it 'sets next_review_at to nil when changing to not_studied' do
+        word = create(:word, wordbook: wordbook, status: 'easy', next_review_at: 5.days.from_now)
+
+        patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}",
+              params: { word: { status: 'not_studied' } }, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['next_review_at']).to be_nil
+      end
+
+      it 'sets next_review_at to now + interval when changing from not_studied' do
+        word = create(:word, wordbook: wordbook, status: 'not_studied', next_review_at: nil)
+
+        freeze_time do
+          patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}",
+                params: { word: { status: 'easy' } }, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          expect(Time.zone.parse(response.parsed_body['next_review_at'])).to be_within(1.second).of(7.days.from_now)
+        end
+      end
+
+      it 'ignores client-supplied next_review_at when status changes' do
+        word = create(:word, wordbook: wordbook, status: 'easy', next_review_at: 10.days.from_now)
+        client_supplied = 99.days.from_now
+
+        freeze_time do
+          patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}",
+                params: { word: { status: 'hard', next_review_at: client_supplied } }, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          returned = Time.zone.parse(response.parsed_body['next_review_at'])
+          expect(returned).not_to be_within(1.second).of(client_supplied)
+        end
+      end
+    end
+
+    context 'when status is unchanged' do
+      it 'accepts client-supplied next_review_at as-is' do
+        word = create(:word, wordbook: wordbook, status: 'easy', next_review_at: 5.days.from_now)
+        new_date = 20.days.from_now
+
+        patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}",
+              params: { word: { next_review_at: new_date } }, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(Time.zone.parse(response.parsed_body['next_review_at'])).to be_within(1.second).of(new_date)
+      end
     end
   end
 


### PR DESCRIPTION
Closes #75

## Summary

- Add `Reviewable` concern with `before_update` callback that recalculates `next_review_at` when a word's status changes
- Include the concern in the `Word` model
- No controller changes needed — the existing `@word.update!(word_params)` triggers the callback automatically

## Test plan

- [x] Unit tests for `Reviewable` concern covering all edge cases (9 examples)
- [x] Integration tests for PATCH endpoint verifying recalculated values (5 examples)
- [x] All 33 specs pass

Generated with [Claude Code](https://claude.ai/code)