### PR TITLE
fix: recalculate next_review_at when reviewing a past-due word

### DIFF
--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -12,10 +12,8 @@ module Reviewable
 
     if status.to_sym == :not_studied
       self.next_review_at = nil
-    elsif next_review_at.nil? || status_was.to_sym == :not_studied
+    elsif next_review_at.nil? || status_was.to_sym == :not_studied || next_review_at <= Time.current
       self.next_review_at = Time.current + interval_for(status, setting)
-    elsif next_review_at <= Time.current
-      # already past (immediately reviewable) — keep as-is
     else
       adjustment = interval_for(status, setting) - interval_for(status_was, setting)
       self.next_review_at = next_review_at + adjustment

--- a/spec/models/concerns/reviewable_spec.rb
+++ b/spec/models/concerns/reviewable_spec.rb
@@ -60,12 +60,13 @@ RSpec.describe Reviewable, type: :model do
     end
 
     context 'when next_review_at is in the past (immediately reviewable)' do
-      let(:past_date) { 2.days.ago }
-      let(:word) { create(:word, wordbook: wordbook, status: 'easy', next_review_at: past_date) }
+      let(:word) { create(:word, wordbook: wordbook, status: 'easy', next_review_at: 2.days.ago) }
 
-      it 'keeps next_review_at unchanged' do
-        word.update!(status: 'hard')
-        expect(word.reload.next_review_at).to be_within(1.second).of(past_date)
+      it 'sets next_review_at to now + new_interval' do
+        freeze_time do
+          word.update!(status: 'hard')
+          expect(word.next_review_at).to be_within(1.second).of(1.day.from_now)
+        end
       end
     end
 


### PR DESCRIPTION
Closes #122

## Summary

- `reviewable.rb`: `next_review_at` が過去の場合、新しいステータスに基づいて `next_review_at` を再計算するよう修正
- `reviewable_spec.rb`: 新しい動作に合わせてテストを更新

Generated with [Claude Code](https://claude.ai/code)