### PR TITLE
test: replace be_within with eq in spec files

### DIFF
--- a/spec/models/concerns/reviewable_spec.rb
+++ b/spec/models/concerns/reviewable_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Reviewable, type: :model do
       it 'does not recalculate next_review_at' do
         original = word.next_review_at
         word.update!(spelling: 'changed')
-        expect(word.next_review_at).to be_within(1.second).of(original)
+        expect(word.next_review_at).to eq(original)
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe Reviewable, type: :model do
       it 'sets next_review_at to now + hard_interval' do
         freeze_time do
           word.update!(status: 'hard')
-          expect(word.next_review_at).to be_within(1.second).of(1.day.from_now)
+          expect(word.next_review_at).to eq(1.day.from_now)
         end
       end
     end
@@ -43,18 +43,7 @@ RSpec.describe Reviewable, type: :model do
       it 'sets next_review_at to now + easy_interval' do
         freeze_time do
           word.update!(status: 'easy')
-          expect(word.next_review_at).to be_within(1.second).of(7.days.from_now)
-        end
-      end
-    end
-
-    context 'when next_review_at is nil (easy word never reviewed)' do
-      let(:word) { create(:word, wordbook: wordbook, status: 'easy', next_review_at: nil) }
-
-      it 'sets next_review_at to now + new_interval' do
-        freeze_time do
-          word.update!(status: 'hard')
-          expect(word.next_review_at).to be_within(1.second).of(1.day.from_now)
+          expect(word.next_review_at).to eq(7.days.from_now)
         end
       end
     end
@@ -64,8 +53,9 @@ RSpec.describe Reviewable, type: :model do
       let(:word) { create(:word, wordbook: wordbook, status: 'easy', next_review_at: past_date) }
 
       it 'keeps next_review_at unchanged' do
+        db_past_date = word.reload.next_review_at
         word.update!(status: 'hard')
-        expect(word.reload.next_review_at).to be_within(1.second).of(past_date)
+        expect(word.reload.next_review_at).to eq(db_past_date)
       end
     end
 
@@ -77,7 +67,7 @@ RSpec.describe Reviewable, type: :model do
         freeze_time do
           word.update!(status: 'hard')
           # easy_interval(7d) - hard_interval(1d) = 6d earlier
-          expect(word.next_review_at).to be_within(1.second).of(future_date - 6.days)
+          expect(word.next_review_at).to eq(future_date - 6.days)
         end
       end
     end
@@ -90,7 +80,7 @@ RSpec.describe Reviewable, type: :model do
         freeze_time do
           word.update!(status: 'easy')
           # hard_interval(1d) - easy_interval(7d) = -6d (later)
-          expect(word.next_review_at).to be_within(1.second).of(future_date + 6.days)
+          expect(word.next_review_at).to eq(future_date + 6.days)
         end
       end
     end
@@ -106,7 +96,7 @@ RSpec.describe Reviewable, type: :model do
         freeze_time do
           word.update!(status: 'hard')
           # easy_interval(10d) - hard_interval(2d) = 8d earlier
-          expect(word.next_review_at).to be_within(1.second).of(future_date - 8.days)
+          expect(word.next_review_at).to eq(future_date - 8.days)
         end
       end
     end

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
           expect(response).to have_http_status(:ok)
           # easy(7d) → hard(1d): 6 days earlier
           expected = 10.days.from_now - 6.days
-          expect(Time.zone.parse(response.parsed_body['next_review_at'])).to be_within(1.second).of(expected)
+          expect(Time.zone.parse(response.parsed_body['next_review_at'])).to eq(expected)
         end
       end
 
@@ -221,7 +221,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
                 params: { word: { status: 'easy' } }, headers: headers
 
           expect(response).to have_http_status(:ok)
-          expect(Time.zone.parse(response.parsed_body['next_review_at'])).to be_within(1.second).of(7.days.from_now)
+          expect(Time.zone.parse(response.parsed_body['next_review_at'])).to eq(7.days.from_now)
         end
       end
 


### PR DESCRIPTION
Fixes #121

- Replace overly loose `be_within(1.second)` matchers with `eq` in `reviewable_spec.rb` and `words_spec.rb`
- Remove impossible-state test for `status: 'easy'` with `next_review_at: nil`
- Fix `past_date` comparison to use DB-round-tripped value

Generated with [Claude Code](https://claude.ai/code)