### PR TITLE
test: stub User.create! instead of Wordbook.new for RecordNotUnique test

### DIFF
--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe 'ErrorsController', type: :request do
     end
 
     it 'returns conflict for ActiveRecord::RecordNotUnique' do
-      allow(Wordbook).to receive(:new).and_raise(ActiveRecord::RecordNotUnique.new('Duplicate entry'))
+      allow(User).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique.new('Duplicate entry'))
 
-      post '/api/v1/wordbooks', params: { wordbook: { title: 'Test' } }, headers: headers
+      post '/api/v1/auth/guest'
 
       expect(response).to have_http_status(:conflict)
       expect(response.parsed_body['error']).to eq('Duplicate record')


### PR DESCRIPTION
## Summary
- Stub `User.create!` on the guest auth endpoint instead of `Wordbook.new` on the wordbooks endpoint for `ActiveRecord::RecordNotUnique` error handling test
- `RecordNotUnique` is raised during DB writes (`save!`/`create!`), not during object instantiation (`new`), so the previous stub was unrealistic
- `User` model has actual unique constraints (email, provider+provider_uid), making it a more appropriate model for this test