### PR TITLE
Support nested attributes for word creation endpoint

### DIFF
--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -18,7 +18,7 @@ module Api
       def create
         word = @wordbook.words.new(word_params)
         word.save!
-        render json: WordResource.new(word).serialize, status: :created
+        render json: WordResource.new(word, params: { includes: %w[meanings examples] }).serialize, status: :created
       end
 
       def update
@@ -50,7 +50,11 @@ module Api
       end
 
       def word_params
-        params.expect(word: %i[spelling status])
+        params.expect(word: [
+                        :spelling, :status,
+                        { meanings_attributes: [%i[definition display_order]],
+                          examples_attributes: [%i[sentence translation display_order]] }
+                      ])
       end
     end
   end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -6,6 +6,9 @@ class Word < ApplicationRecord
   has_many :examples, dependent: :destroy
   has_one :first_meaning, -> { order(:display_order) }, class_name: 'Meaning', dependent: nil, inverse_of: false
 
+  accepts_nested_attributes_for :meanings
+  accepts_nested_attributes_for :examples
+
   validates :spelling, presence: true
   validates :status, presence: true
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -271,7 +271,11 @@ paths:
           $ref: "#/components/responses/NotFound"
     post:
       tags: [Words]
-      summary: Create a word in a wordbook
+      summary: Create a word with optional nested meanings and examples
+      description: |
+        Creates a word in the wordbook. Optionally accepts nested `meanings_attributes`
+        and `examples_attributes` to create related records in a single atomic transaction.
+        The response always includes `meanings` and `examples` arrays.
       security:
         - bearerAuth: []
       requestBody:
@@ -290,17 +294,39 @@ paths:
                       type: string
                     status:
                       $ref: "#/components/schemas/WordStatus"
-                    next_review_at:
-                      type: string
-                      format: date-time
-                      nullable: true
+                    meanings_attributes:
+                      type: array
+                      description: Optional nested meanings to create with the word
+                      items:
+                        type: object
+                        required: [definition, display_order]
+                        properties:
+                          definition:
+                            type: string
+                          display_order:
+                            type: integer
+                            minimum: 1
+                    examples_attributes:
+                      type: array
+                      description: Optional nested examples to create with the word
+                      items:
+                        type: object
+                        required: [sentence, translation, display_order]
+                        properties:
+                          sentence:
+                            type: string
+                          translation:
+                            type: string
+                          display_order:
+                            type: integer
+                            minimum: 1
       responses:
         "201":
           description: Created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Word"
+                $ref: "#/components/schemas/WordWithRelations"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Word, type: :model do
     it { is_expected.to have_many(:meanings).dependent(:destroy) }
     it { is_expected.to have_many(:examples).dependent(:destroy) }
     it { is_expected.to have_one(:first_meaning).class_name('Meaning') }
+    it { is_expected.to accept_nested_attributes_for(:meanings) }
+    it { is_expected.to accept_nested_attributes_for(:examples) }
   end
 
   describe 'validations' do

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -156,8 +156,8 @@ RSpec.describe 'Api::V1::Words', type: :request do
           word: {
             spelling: 'apple', status: 'not_studied',
             meanings_attributes: [
-              { definition: 'a fruit', display_order: 1 },
-              { definition: 'a tech company', display_order: 2 }
+              { definition: 'りんご', display_order: 1 },
+              { definition: 'アップル社', display_order: 2 }
             ]
           }
         }
@@ -171,7 +171,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
         expect(response).to have_http_status(:created)
         body = response.parsed_body
         expect(body['meanings'].size).to eq(2)
-        expect(body['meanings'].pluck('definition')).to eq(['a fruit', 'a tech company'])
+        expect(body['meanings'].pluck('definition')).to eq(%w[りんご アップル社])
       end
     end
 
@@ -204,7 +204,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
         {
           word: {
             spelling: 'run', status: 'not_studied',
-            meanings_attributes: [{ definition: 'to move quickly', display_order: 1 }],
+            meanings_attributes: [{ definition: '走る', display_order: 1 }],
             examples_attributes: [
               { sentence: 'I run every morning.', translation: '毎朝走ります。', display_order: 1 }
             ]

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -136,14 +136,131 @@ RSpec.describe 'Api::V1::Words', type: :request do
 
   describe 'POST /api/v1/wordbooks/:wordbook_id/words' do
     context 'with valid params' do
-      it 'creates a word' do
+      it 'creates a word and returns meanings and examples in response' do
         expect do
           post "/api/v1/wordbooks/#{wordbook.id}/words",
                params: { word: { spelling: 'banana', status: 'not_studied' } }, headers: headers
         end.to change(Word, :count).by(1)
 
         expect(response).to have_http_status(:created)
-        expect(response.parsed_body['spelling']).to eq('banana')
+        body = response.parsed_body
+        expect(body['spelling']).to eq('banana')
+        expect(body['meanings']).to eq([])
+        expect(body['examples']).to eq([])
+      end
+    end
+
+    context 'with meanings_attributes' do
+      let(:params) do
+        {
+          word: {
+            spelling: 'apple', status: 'not_studied',
+            meanings_attributes: [
+              { definition: 'a fruit', display_order: 1 },
+              { definition: 'a tech company', display_order: 2 }
+            ]
+          }
+        }
+      end
+
+      it 'creates a word with meanings in a single request' do
+        expect do
+          post "/api/v1/wordbooks/#{wordbook.id}/words", params: params, headers: headers
+        end.to change(Word, :count).by(1).and change(Meaning, :count).by(2)
+
+        expect(response).to have_http_status(:created)
+        body = response.parsed_body
+        expect(body['meanings'].size).to eq(2)
+        expect(body['meanings'].pluck('definition')).to eq(['a fruit', 'a tech company'])
+      end
+    end
+
+    context 'with examples_attributes' do
+      let(:params) do
+        {
+          word: {
+            spelling: 'hello', status: 'not_studied',
+            examples_attributes: [
+              { sentence: 'Hello, world!', translation: 'こんにちは、世界！', display_order: 1 }
+            ]
+          }
+        }
+      end
+
+      it 'creates a word with examples in a single request' do
+        expect do
+          post "/api/v1/wordbooks/#{wordbook.id}/words", params: params, headers: headers
+        end.to change(Word, :count).by(1).and change(Example, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        body = response.parsed_body
+        expect(body['examples'].size).to eq(1)
+        expect(body['examples'].first['sentence']).to eq('Hello, world!')
+      end
+    end
+
+    context 'with both meanings_attributes and examples_attributes' do
+      let(:params) do
+        {
+          word: {
+            spelling: 'run', status: 'not_studied',
+            meanings_attributes: [{ definition: 'to move quickly', display_order: 1 }],
+            examples_attributes: [
+              { sentence: 'I run every morning.', translation: '毎朝走ります。', display_order: 1 }
+            ]
+          }
+        }
+      end
+
+      it 'creates a word with meanings and examples atomically' do
+        expect do
+          post "/api/v1/wordbooks/#{wordbook.id}/words", params: params, headers: headers
+        end.to change(Word, :count).by(1)
+                                   .and change(Meaning, :count).by(1)
+                                                               .and change(Example, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        body = response.parsed_body
+        expect(body['meanings'].size).to eq(1)
+        expect(body['examples'].size).to eq(1)
+      end
+    end
+
+    context 'with invalid nested attributes' do
+      it 'does not create any records when meaning validation fails' do
+        params = {
+          word: {
+            spelling: 'apple',
+            status: 'not_studied',
+            meanings_attributes: [{ definition: '', display_order: 1 }]
+          }
+        }
+
+        word_count = Word.count
+        meaning_count = Meaning.count
+        post "/api/v1/wordbooks/#{wordbook.id}/words", params: params, headers: headers
+
+        expect(Word.count).to eq(word_count)
+        expect(Meaning.count).to eq(meaning_count)
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it 'does not create any records when example validation fails' do
+        params = {
+          word: {
+            spelling: 'apple',
+            status: 'not_studied',
+            examples_attributes: [{ sentence: '', translation: 'trans', display_order: 1 }]
+          }
+        }
+
+        word_count = Word.count
+        example_count = Example.count
+        post "/api/v1/wordbooks/#{wordbook.id}/words", params: params, headers: headers
+
+        expect(Word.count).to eq(word_count)
+        expect(Example.count).to eq(example_count)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 


### PR DESCRIPTION
## Summary

- Add `accepts_nested_attributes_for :meanings, :examples` to the Word model
- Update `POST /api/v1/wordbooks/:wordbook_id/words` to accept optional `meanings_attributes` and `examples_attributes`, enabling atomic creation of word + meanings + examples in a single request
- Create response now always includes `meanings` and `examples` arrays
- Update OpenAPI spec to reflect the new request/response schema

## Test plan

- [x] Existing word creation test updated to verify new response shape (meanings/examples arrays)
- [x] Creation with `meanings_attributes` only
- [x] Creation with `examples_attributes` only
- [x] Creation with both nested attributes atomically
- [x] Validation error on nested meaning rolls back all records
- [x] Validation error on nested example rolls back all records
- [x] Backward compatibility: creation without nested attributes still works

Closes #126