### PR TITLE
feat(words): set default status and exclude it from create params

### DIFF
--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -16,13 +16,13 @@ module Api
       end
 
       def create
-        word = @wordbook.words.new(word_params)
+        word = @wordbook.words.new(create_word_params)
         word.save!
         render json: WordResource.new(word, params: { includes: %w[meanings examples] }).serialize, status: :created
       end
 
       def update
-        @word.update!(word_params)
+        @word.update!(update_word_params)
         render json: WordResource.new(@word).serialize
       end
 
@@ -49,7 +49,15 @@ module Api
         params[:include].split(',').map(&:strip).select { |i| ALLOWED_INCLUDES.include?(i) }
       end
 
-      def word_params
+      def create_word_params
+        params.expect(word: [
+                        :spelling,
+                        { meanings_attributes: [%i[definition display_order]],
+                          examples_attributes: [%i[sentence translation display_order]] }
+                      ])
+      end
+
+      def update_word_params
         params.expect(word: [
                         :spelling, :status,
                         { meanings_attributes: [%i[definition display_order]],

--- a/db/migrate/20260423130948_add_default_status_to_words.rb
+++ b/db/migrate/20260423130948_add_default_status_to_words.rb
@@ -1,0 +1,5 @@
+class AddDefaultStatusToWords < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :words, :status, from: nil, to: 'not_studied'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_14_121300) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_23_130948) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -73,7 +73,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_121300) do
     t.datetime "created_at", null: false
     t.datetime "next_review_at"
     t.string "spelling", null: false
-    t.string "status", null: false
+    t.string "status", default: "not_studied", null: false
     t.datetime "updated_at", null: false
     t.bigint "wordbook_id", null: false
     t.index ["wordbook_id"], name: "index_words_on_wordbook_id"

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -139,12 +139,13 @@ RSpec.describe 'Api::V1::Words', type: :request do
       it 'creates a word and returns meanings and examples in response' do
         expect do
           post "/api/v1/wordbooks/#{wordbook.id}/words",
-               params: { word: { spelling: 'banana', status: 'not_studied' } }, headers: headers
+               params: { word: { spelling: 'banana' } }, headers: headers
         end.to change(Word, :count).by(1)
 
         expect(response).to have_http_status(:created)
         body = response.parsed_body
         expect(body['spelling']).to eq('banana')
+        expect(body['status']).to eq('not_studied')
         expect(body['meanings']).to eq([])
         expect(body['examples']).to eq([])
       end
@@ -154,7 +155,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
       let(:params) do
         {
           word: {
-            spelling: 'apple', status: 'not_studied',
+            spelling: 'apple',
             meanings_attributes: [
               { definition: 'りんご', display_order: 1 },
               { definition: 'アップル社', display_order: 2 }
@@ -179,7 +180,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
       let(:params) do
         {
           word: {
-            spelling: 'hello', status: 'not_studied',
+            spelling: 'hello',
             examples_attributes: [
               { sentence: 'Hello, world!', translation: 'こんにちは、世界！', display_order: 1 }
             ]
@@ -203,7 +204,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
       let(:params) do
         {
           word: {
-            spelling: 'run', status: 'not_studied',
+            spelling: 'run',
             meanings_attributes: [{ definition: '走る', display_order: 1 }],
             examples_attributes: [
               { sentence: 'I run every morning.', translation: '毎朝走ります。', display_order: 1 }
@@ -231,7 +232,6 @@ RSpec.describe 'Api::V1::Words', type: :request do
         params = {
           word: {
             spelling: 'apple',
-            status: 'not_studied',
             meanings_attributes: [{ definition: '', display_order: 1 }]
           }
         }
@@ -249,7 +249,6 @@ RSpec.describe 'Api::V1::Words', type: :request do
         params = {
           word: {
             spelling: 'apple',
-            status: 'not_studied',
             examples_attributes: [{ sentence: '', translation: 'trans', display_order: 1 }]
           }
         }
@@ -264,9 +263,17 @@ RSpec.describe 'Api::V1::Words', type: :request do
       end
     end
 
+    it 'ignores status parameter and always sets not_studied' do
+      post "/api/v1/wordbooks/#{wordbook.id}/words",
+           params: { word: { spelling: 'banana', status: 'easy' } }, headers: headers
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['status']).to eq('not_studied')
+    end
+
     context 'with invalid params' do
       it 'returns unprocessable_content' do
-        post "/api/v1/wordbooks/#{wordbook.id}/words", params: { word: { spelling: '', status: 'not_studied' } },
+        post "/api/v1/wordbooks/#{wordbook.id}/words", params: { word: { spelling: '' } },
                                                        headers: headers
 
         expect(response).to have_http_status(:unprocessable_content)
@@ -278,7 +285,7 @@ RSpec.describe 'Api::V1::Words', type: :request do
       other_wordbook = create(:wordbook)
 
       post "/api/v1/wordbooks/#{other_wordbook.id}/words",
-           params: { word: { spelling: 'test', status: 'not_studied' } }, headers: headers
+           params: { word: { spelling: 'test' } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end


### PR DESCRIPTION
## Summary
- Add DB-level default of `'not_studied'` on `words.status` column so new words always start in the correct initial state
- Split `word_params` into `create_word_params` (without status) and `update_word_params` (with status) to prevent clients from setting an arbitrary initial status

Closes #130