### PR TITLE
feat(validation): add length validations to string and text columns

### DIFF
--- a/app/models/example.rb
+++ b/app/models/example.rb
@@ -1,7 +1,7 @@
 class Example < ApplicationRecord
   belongs_to :word
 
-  validates :sentence, presence: true
-  validates :translation, presence: true
+  validates :sentence, presence: true, length: { maximum: 1000 }
+  validates :translation, presence: true, length: { maximum: 1000 }
   validates :display_order, presence: true, numericality: { only_integer: true, greater_than: 0 }
 end

--- a/app/models/meaning.rb
+++ b/app/models/meaning.rb
@@ -1,6 +1,6 @@
 class Meaning < ApplicationRecord
   belongs_to :word
 
-  validates :definition, presence: true
+  validates :definition, presence: true, length: { maximum: 1000 }
   validates :display_order, presence: true, numericality: { only_integer: true, greater_than: 0 }
 end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -9,7 +9,7 @@ class Word < ApplicationRecord
   accepts_nested_attributes_for :meanings
   accepts_nested_attributes_for :examples
 
-  validates :spelling, presence: true
+  validates :spelling, presence: true, length: { maximum: 255 }
   validates :status, presence: true
 
   enum :status, { not_studied: 'not_studied', hard: 'hard', uncertain: 'uncertain', easy: 'easy' }

--- a/app/models/wordbook.rb
+++ b/app/models/wordbook.rb
@@ -2,5 +2,5 @@ class Wordbook < ApplicationRecord
   belongs_to :user
   has_many :words, dependent: :destroy
 
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: 255 }
 end

--- a/db/migrate/20260424122013_add_length_check_constraints.rb
+++ b/db/migrate/20260424122013_add_length_check_constraints.rb
@@ -1,0 +1,9 @@
+class AddLengthCheckConstraints < ActiveRecord::Migration[8.1]
+  def change
+    add_check_constraint :wordbooks, 'char_length(title) <= 255', name: 'check_wordbooks_title_length'
+    add_check_constraint :words, 'char_length(spelling) <= 255', name: 'check_words_spelling_length'
+    add_check_constraint :meanings, 'char_length(definition) <= 1000', name: 'check_meanings_definition_length'
+    add_check_constraint :examples, 'char_length(sentence) <= 1000', name: 'check_examples_sentence_length'
+    add_check_constraint :examples, 'char_length(translation) <= 1000', name: 'check_examples_translation_length'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_23_130948) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_122013) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,6 +22,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_130948) do
     t.datetime "updated_at", null: false
     t.bigint "word_id", null: false
     t.index ["word_id"], name: "index_examples_on_word_id"
+    t.check_constraint "char_length(sentence) <= 1000", name: "check_examples_sentence_length"
+    t.check_constraint "char_length(translation) <= 1000", name: "check_examples_translation_length"
   end
 
   create_table "meanings", force: :cascade do |t|
@@ -31,6 +33,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_130948) do
     t.datetime "updated_at", null: false
     t.bigint "word_id", null: false
     t.index ["word_id"], name: "index_meanings_on_word_id"
+    t.check_constraint "char_length(definition) <= 1000", name: "check_meanings_definition_length"
   end
 
   create_table "settings", force: :cascade do |t|
@@ -67,6 +70,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_130948) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_wordbooks_on_user_id"
+    t.check_constraint "char_length(title::text) <= 255", name: "check_wordbooks_title_length"
   end
 
   create_table "words", force: :cascade do |t|
@@ -77,6 +81,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_130948) do
     t.datetime "updated_at", null: false
     t.bigint "wordbook_id", null: false
     t.index ["wordbook_id"], name: "index_words_on_wordbook_id"
+    t.check_constraint "char_length(spelling::text) <= 255", name: "check_words_spelling_length"
     t.check_constraint "status::text = ANY (ARRAY['not_studied'::character varying, 'hard'::character varying, 'uncertain'::character varying, 'easy'::character varying]::text[])", name: "check_words_status_values"
   end
 

--- a/spec/models/example_spec.rb
+++ b/spec/models/example_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Example, type: :model do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:sentence) }
+    it { is_expected.to validate_length_of(:sentence).is_at_most(1000) }
     it { is_expected.to validate_presence_of(:translation) }
+    it { is_expected.to validate_length_of(:translation).is_at_most(1000) }
     it { is_expected.to validate_presence_of(:display_order) }
     it { is_expected.to validate_numericality_of(:display_order).only_integer.is_greater_than(0) }
   end

--- a/spec/models/meaning_spec.rb
+++ b/spec/models/meaning_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Meaning, type: :model do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:definition) }
+    it { is_expected.to validate_length_of(:definition).is_at_most(1000) }
     it { is_expected.to validate_presence_of(:display_order) }
     it { is_expected.to validate_numericality_of(:display_order).only_integer.is_greater_than(0) }
   end

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Word, type: :model do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:spelling) }
+    it { is_expected.to validate_length_of(:spelling).is_at_most(255) }
     it { is_expected.to validate_presence_of(:status) }
   end
 

--- a/spec/models/wordbook_spec.rb
+++ b/spec/models/wordbook_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Wordbook, type: :model do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_length_of(:title).is_at_most(255) }
   end
 
   describe 'factory' do


### PR DESCRIPTION
## Summary
- Add model-level length validations to user-input columns: `Wordbook.title` (255), `Word.spelling` (255), `Meaning.definition` (1000), `Example.sentence` (1000), `Example.translation` (1000)
- Add corresponding DB check constraints using `char_length()` for defense-in-depth
- Add model specs using shoulda-matchers `validate_length_of`