### PR TITLE
Fix: replace deprecated :unprocessable_entity with :unprocessable_content

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,7 +49,7 @@ module WordbeetleApi
       'AuthenticationError' => :unauthorized,
       'BadRequestError' => :bad_request,
       'ConflictError' => :conflict,
-      'UnprocessableEntityError' => :unprocessable_entity
+      'UnprocessableEntityError' => :unprocessable_content
     )
   end
 end

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'ErrorsController', type: :request do
 
         get '/422', env: { 'action_dispatch.exception' => exception }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.parsed_body['error']).to eq('Unprocessable entity')
         expect(Rails.logger).to have_received(:warn).with(
           a_string_matching(%r{Client error: 422 GET /422 - ActiveRecord::RecordInvalid:})


### PR DESCRIPTION
## Summary

- Replace deprecated `:unprocessable_entity` with `:unprocessable_content` in `config/application.rb` and `spec/requests/errors_controller_spec.rb`
- Rails 8.1 deprecated `:unprocessable_entity` in favor of `:unprocessable_content` to align with RFC 9110

## Test plan

- [x] `bundle exec rspec` passes with 247 examples, 0 failures
- [x] Deprecation warning no longer appears