### PR TITLE
feat: move examples association from words to meanings

### DIFF
--- a/app/controllers/api/v1/examples_controller.rb
+++ b/app/controllers/api/v1/examples_controller.rb
@@ -1,11 +1,11 @@
 module Api
   module V1
     class ExamplesController < ApplicationController
-      before_action :set_word
+      before_action :set_meaning
       before_action :set_example, only: %i[show update destroy]
 
       def index
-        examples = @word.examples
+        examples = @meaning.examples
         render_paginated(examples, ExampleResource)
       end
 
@@ -14,7 +14,7 @@ module Api
       end
 
       def create
-        example = @word.examples.new(example_params)
+        example = @meaning.examples.new(example_params)
         example.save!
         render json: ExampleResource.new(example).serialize, status: :created
       end
@@ -31,12 +31,13 @@ module Api
 
       private
 
-      def set_word
-        @word = current_user.wordbooks.find(params[:wordbook_id]).words.find(params[:word_id])
+      def set_meaning
+        word = current_user.wordbooks.find(params[:wordbook_id]).words.find(params[:word_id])
+        @meaning = word.meanings.find(params[:meaning_id])
       end
 
       def set_example
-        @example = @word.examples.find(params[:id])
+        @example = @meaning.examples.find(params[:id])
       end
 
       def example_params

--- a/app/controllers/api/v1/test/words_controller.rb
+++ b/app/controllers/api/v1/test/words_controller.rb
@@ -4,7 +4,7 @@ module Api
       class WordsController < ApplicationController
         def index
           wordbook = current_user.wordbooks.find(params[:wordbook_id])
-          words = wordbook.words.reviewable.includes(:meanings, :examples)
+          words = wordbook.words.reviewable.includes(meanings: :examples)
 
           render json: {
             wordbook: WordbookResource.new(wordbook).serializable_hash,

--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -40,7 +40,11 @@ module Api
       def set_word
         includes = parse_includes
         scope = @wordbook.words
-        scope = scope.includes(*includes.map(&:to_sym)) if includes.any?
+        if includes.include?('examples')
+          scope = scope.includes(meanings: :examples)
+        elsif includes.include?('meanings')
+          scope = scope.includes(:meanings)
+        end
         @word = scope.find(params[:id])
       end
 
@@ -53,16 +57,16 @@ module Api
       def create_word_params
         params.expect(word: [
                         :spelling,
-                        { meanings_attributes: [%i[definition display_order]],
-                          examples_attributes: [%i[sentence translation display_order]] }
+                        { meanings_attributes: [[:definition, :display_order,
+                                                 { examples_attributes: [%i[sentence translation display_order]] }]] }
                       ])
       end
 
       def update_word_params
         params.expect(word: [
                         :spelling, :status,
-                        { meanings_attributes: [%i[definition display_order]],
-                          examples_attributes: [%i[sentence translation display_order]] }
+                        { meanings_attributes: [[:definition, :display_order,
+                                                 { examples_attributes: [%i[sentence translation display_order]] }]] }
                       ])
       end
     end

--- a/app/models/example.rb
+++ b/app/models/example.rb
@@ -1,5 +1,5 @@
 class Example < ApplicationRecord
-  belongs_to :word
+  belongs_to :meaning
 
   validates :sentence, presence: true, length: { maximum: 1000 }
   validates :translation, presence: true, length: { maximum: 1000 }

--- a/app/models/meaning.rb
+++ b/app/models/meaning.rb
@@ -1,5 +1,8 @@
 class Meaning < ApplicationRecord
   belongs_to :word
+  has_many :examples, dependent: :destroy
+
+  accepts_nested_attributes_for :examples
 
   validates :definition, presence: true, length: { maximum: 1000 }
   validates :display_order, presence: true, numericality: { only_integer: true, greater_than: 0 }

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -3,11 +3,10 @@ class Word < ApplicationRecord
 
   belongs_to :wordbook
   has_many :meanings, dependent: :destroy
-  has_many :examples, dependent: :destroy
+  has_many :examples, through: :meanings
   has_one :first_meaning, -> { order(:display_order) }, class_name: 'Meaning', dependent: nil, inverse_of: false
 
   accepts_nested_attributes_for :meanings
-  accepts_nested_attributes_for :examples
 
   validates :spelling, presence: true, length: { maximum: 255 }
   validates :status, presence: true

--- a/app/resources/word_resource.rb
+++ b/app/resources/word_resource.rb
@@ -7,15 +7,18 @@ class WordResource
     word.first_meaning ? { definition: word.first_meaning.definition } : nil
   end
 
-  attribute :meanings, if: proc { |_word| params[:includes]&.include?('meanings') } do |word|
+  attribute :meanings, if: proc { |_word|
+    params[:includes]&.include?('meanings') || params[:includes]&.include?('examples')
+  } do |word|
+    include_examples = params[:includes]&.include?('examples')
     word.meanings.sort_by(&:display_order).map do |m|
-      { id: m.id, definition: m.definition, display_order: m.display_order }
-    end
-  end
-
-  attribute :examples, if: proc { |_word| params[:includes]&.include?('examples') } do |word|
-    word.examples.sort_by(&:display_order).map do |e|
-      { id: e.id, sentence: e.sentence, translation: e.translation, display_order: e.display_order }
+      meaning_hash = { id: m.id, definition: m.definition, display_order: m.display_order }
+      if include_examples
+        meaning_hash[:examples] = m.examples.sort_by(&:display_order).map do |e|
+          { id: e.id, sentence: e.sentence, translation: e.translation, display_order: e.display_order }
+        end
+      end
+      meaning_hash
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,9 @@ Rails.application.routes.draw do
           resources :words, only: [:index]
         end
         resources :words do
-          resources :meanings
-          resources :examples
+          resources :meanings do
+            resources :examples
+          end
         end
       end
       resource :setting, only: %i[show create update destroy]

--- a/db/migrate/20260425105635_move_examples_from_words_to_meanings.rb
+++ b/db/migrate/20260425105635_move_examples_from_words_to_meanings.rb
@@ -1,0 +1,58 @@
+class MoveExamplesFromWordsToMeanings < ActiveRecord::Migration[8.1]
+  def up
+    add_reference :examples, :meaning, null: true, foreign_key: true
+
+    # Assign each example to the first meaning (by display_order) of its word
+    execute <<~SQL
+      UPDATE examples
+      SET meaning_id = (
+        SELECT meanings.id
+        FROM meanings
+        WHERE meanings.word_id = examples.word_id
+        ORDER BY meanings.display_order ASC
+        LIMIT 1
+      )
+    SQL
+
+    # Create a default meaning for words that have examples but no meanings
+    execute <<~SQL
+      INSERT INTO meanings (word_id, definition, display_order, created_at, updated_at)
+      SELECT DISTINCT e.word_id, '(定義なし)', 1, NOW(), NOW()
+      FROM examples e
+      WHERE e.meaning_id IS NULL
+        AND NOT EXISTS (SELECT 1 FROM meanings m WHERE m.word_id = e.word_id)
+    SQL
+
+    # Re-assign any remaining orphaned examples
+    execute <<~SQL
+      UPDATE examples
+      SET meaning_id = (
+        SELECT meanings.id
+        FROM meanings
+        WHERE meanings.word_id = examples.word_id
+        ORDER BY meanings.display_order ASC
+        LIMIT 1
+      )
+      WHERE meaning_id IS NULL
+    SQL
+
+    change_column_null :examples, :meaning_id, false
+    remove_reference :examples, :word, foreign_key: true
+  end
+
+  def down
+    add_reference :examples, :word, null: true, foreign_key: true
+
+    execute <<~SQL
+      UPDATE examples
+      SET word_id = (
+        SELECT meanings.word_id
+        FROM meanings
+        WHERE meanings.id = examples.meaning_id
+      )
+    SQL
+
+    change_column_null :examples, :word_id, false
+    remove_reference :examples, :meaning, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_24_122013) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_25_105635) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "examples", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "display_order", null: false
+    t.bigint "meaning_id", null: false
     t.text "sentence", null: false
     t.text "translation", null: false
     t.datetime "updated_at", null: false
-    t.bigint "word_id", null: false
-    t.index ["word_id"], name: "index_examples_on_word_id"
+    t.index ["meaning_id"], name: "index_examples_on_meaning_id"
     t.check_constraint "char_length(sentence) <= 1000", name: "check_examples_sentence_length"
     t.check_constraint "char_length(translation) <= 1000", name: "check_examples_translation_length"
   end
@@ -85,7 +85,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_122013) do
     t.check_constraint "status::text = ANY (ARRAY['not_studied'::character varying, 'hard'::character varying, 'uncertain'::character varying, 'easy'::character varying]::text[])", name: "check_words_status_values"
   end
 
-  add_foreign_key "examples", "words"
+  add_foreign_key "examples", "meanings"
   add_foreign_key "meanings", "words"
   add_foreign_key "settings", "users"
   add_foreign_key "wordbooks", "users"

--- a/docs/er_diagram.plantuml
+++ b/docs/er_diagram.plantuml
@@ -51,7 +51,7 @@ entity "meanings" as meanings {
 entity "examples" as examples {
   *id : bigint <<PK>>
   --
-  *word_id : bigint <<FK>>
+  *meaning_id : bigint <<FK>>
   *sentence : text
   *translation : text
   *display_order : integer
@@ -74,6 +74,6 @@ users ||--o{ wordbooks : "has many"
 users ||--|| settings : "has one"
 wordbooks ||--o{ words : "has many"
 words ||--o{ meanings : "has many"
-words ||--o{ examples : "has many"
+meanings ||--o{ examples : "has many"
 
 @enduml

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -274,8 +274,9 @@ paths:
       summary: Create a word with optional nested meanings and examples
       description: |
         Creates a word in the wordbook. Optionally accepts nested `meanings_attributes`
-        and `examples_attributes` to create related records in a single atomic transaction.
-        The response always includes `meanings` and `examples` arrays.
+        (with `examples_attributes` inside each meaning) to create related records in a
+        single atomic transaction. The response always includes `meanings` array with
+        nested `examples`.
       security:
         - bearerAuth: []
       requestBody:
@@ -306,20 +307,20 @@ paths:
                           display_order:
                             type: integer
                             minimum: 1
-                    examples_attributes:
-                      type: array
-                      description: Optional nested examples to create with the word
-                      items:
-                        type: object
-                        required: [sentence, translation, display_order]
-                        properties:
-                          sentence:
-                            type: string
-                          translation:
-                            type: string
-                          display_order:
-                            type: integer
-                            minimum: 1
+                          examples_attributes:
+                            type: array
+                            description: Optional nested examples to create with the meaning
+                            items:
+                              type: object
+                              required: [sentence, translation, display_order]
+                              properties:
+                                sentence:
+                                  type: string
+                                translation:
+                                  type: string
+                                display_order:
+                                  type: integer
+                                  minimum: 1
       responses:
         "201":
           description: Created
@@ -356,7 +357,9 @@ paths:
         - name: include
           in: query
           required: false
-          description: "Comma-separated list of relations to include. Allowed values: meanings, examples."
+          description: |
+            Comma-separated list of relations to include. Allowed values: meanings, examples.
+            When examples is specified, meanings are automatically included with nested examples.
           schema:
             type: string
             example: meanings,examples
@@ -599,13 +602,14 @@ paths:
           $ref: "#/components/responses/NotFound"
 
   # ──────────────── Examples ────────────────
-  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/examples:
+  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/meanings/{meaning_id}/examples:
     parameters:
       - $ref: "#/components/parameters/WordbookId"
       - $ref: "#/components/parameters/WordId"
+      - $ref: "#/components/parameters/MeaningId"
     get:
       tags: [Examples]
-      summary: List examples for a word
+      summary: List examples for a meaning
       security:
         - bearerAuth: []
       parameters:
@@ -631,7 +635,7 @@ paths:
           $ref: "#/components/responses/NotFound"
     post:
       tags: [Examples]
-      summary: Create an example for a word
+      summary: Create an example for a meaning
       security:
         - bearerAuth: []
       requestBody:
@@ -673,10 +677,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ValidationErrors"
 
-  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/examples/{id}:
+  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/meanings/{meaning_id}/examples/{id}:
     parameters:
       - $ref: "#/components/parameters/WordbookId"
       - $ref: "#/components/parameters/WordId"
+      - $ref: "#/components/parameters/MeaningId"
       - $ref: "#/components/parameters/Id"
     get:
       tags: [Examples]
@@ -892,6 +897,12 @@ components:
       required: true
       schema:
         type: integer
+    MeaningId:
+      name: meaning_id
+      in: path
+      required: true
+      schema:
+        type: integer
     Page:
       name: page
       in: query
@@ -1023,14 +1034,9 @@ components:
           properties:
             meanings:
               type: array
-              description: Present only when include=meanings is specified
+              description: Present when include=meanings or include=examples is specified
               items:
-                $ref: "#/components/schemas/Meaning"
-            examples:
-              type: array
-              description: Present only when include=examples is specified
-              items:
-                $ref: "#/components/schemas/Example"
+                $ref: "#/components/schemas/MeaningWithExamples"
 
     TestWordsResponse:
       type: object
@@ -1052,11 +1058,7 @@ components:
                   meanings:
                     type: array
                     items:
-                      $ref: "#/components/schemas/Meaning"
-                  examples:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Example"
+                      $ref: "#/components/schemas/MeaningWithExamples"
 
     WordStatus:
       type: string
@@ -1081,12 +1083,23 @@ components:
           type: string
           format: date-time
 
+    MeaningWithExamples:
+      allOf:
+        - $ref: "#/components/schemas/Meaning"
+        - type: object
+          properties:
+            examples:
+              type: array
+              description: Present when include=examples is specified
+              items:
+                $ref: "#/components/schemas/Example"
+
     Example:
       type: object
       properties:
         id:
           type: integer
-        word_id:
+        meaning_id:
           type: integer
         sentence:
           type: string

--- a/spec/factories/examples.rb
+++ b/spec/factories/examples.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :example do
-    association :word
+    association :meaning
     sentence { 'Hello, world!' }
     translation { 'こんにちは、世界！' }
     sequence(:display_order) { |n| n }

--- a/spec/jobs/cleanup_expired_guests_job_spec.rb
+++ b/spec/jobs/cleanup_expired_guests_job_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe CleanupExpiredGuestsJob, type: :job do
         expired_guest = create(:user, :guest, guest_expires_at: 1.day.ago)
         wordbook = create(:wordbook, user: expired_guest)
         word = create(:word, wordbook: wordbook)
-        create(:meaning, word: word)
-        create(:example, word: word)
+        meaning = create(:meaning, word: word)
+        create(:example, meaning: meaning)
         create(:setting, user: expired_guest)
 
         described_class.perform_now
@@ -53,7 +53,7 @@ RSpec.describe CleanupExpiredGuestsJob, type: :job do
         expect(Wordbook.exists?(wordbook.id)).to be false
         expect(Word.exists?(word.id)).to be false
         expect(Meaning.where(word_id: word.id)).to be_empty
-        expect(Example.where(word_id: word.id)).to be_empty
+        expect(Example.where(meaning_id: meaning.id)).to be_empty
       end
     end
   end

--- a/spec/models/example_spec.rb
+++ b/spec/models/example_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Example, type: :model do
   describe 'associations' do
-    it { is_expected.to belong_to(:word) }
+    it { is_expected.to belong_to(:meaning) }
   end
 
   describe 'validations' do

--- a/spec/models/meaning_spec.rb
+++ b/spec/models/meaning_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe Meaning, type: :model do
   describe 'associations' do
     it { is_expected.to belong_to(:word) }
+    it { is_expected.to have_many(:examples).dependent(:destroy) }
+    it { is_expected.to accept_nested_attributes_for(:examples) }
   end
 
   describe 'validations' do

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -4,10 +4,9 @@ RSpec.describe Word, type: :model do
   describe 'associations' do
     it { is_expected.to belong_to(:wordbook) }
     it { is_expected.to have_many(:meanings).dependent(:destroy) }
-    it { is_expected.to have_many(:examples).dependent(:destroy) }
+    it { is_expected.to have_many(:examples).through(:meanings) }
     it { is_expected.to have_one(:first_meaning).class_name('Meaning') }
     it { is_expected.to accept_nested_attributes_for(:meanings) }
-    it { is_expected.to accept_nested_attributes_for(:examples) }
   end
 
   describe 'validations' do

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe 'Api::V1::Auth', type: :request do
         let!(:wordbook) { create(:wordbook, user: guest_user, title: 'Guest Wordbook') }
         let!(:word) { create(:word, wordbook: wordbook, spelling: 'apple') }
         let!(:meaning) { create(:meaning, word: word, definition: 'りんご') }
-        let!(:example) { create(:example, word: word, sentence: 'I like apples.', translation: 'りんごが好きです。') }
+        let!(:example) { create(:example, meaning: meaning, sentence: 'I like apples.', translation: 'りんごが好きです。') }
         let!(:setting) { create(:setting, user: guest_user) }
 
         it 'converts guest user to Google user and returns ok' do

--- a/spec/requests/api/v1/examples_spec.rb
+++ b/spec/requests/api/v1/examples_spec.rb
@@ -5,24 +5,25 @@ RSpec.describe 'Api::V1::Examples', type: :request do
   let(:headers) { auth_headers_for(user) }
   let(:wordbook) { create(:wordbook, user: user) }
   let(:word) { create(:word, wordbook: wordbook) }
+  let(:meaning) { create(:meaning, word: word) }
 
-  describe 'GET /api/v1/wordbooks/:wordbook_id/words/:word_id/examples' do
-    let(:endpoint_path) { "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples" }
+  describe 'GET /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:meaning_id/examples' do
+    let(:endpoint_path) { "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}/examples" }
 
-    it_behaves_like 'paginated endpoint', :example, -> { { word: word } }
+    it_behaves_like 'paginated endpoint', :example, -> { { meaning: meaning } }
 
     it "returns current user's examples" do
-      create_list(:example, 2, word: word)
+      create_list(:example, 2, meaning: meaning)
       create(:example) # another user's example
 
-      get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples", headers: headers
+      get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}/examples", headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['data'].size).to eq(2)
     end
 
     it 'returns 401 without authentication' do
-      get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples"
+      get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}/examples"
 
       expect(response).to have_http_status(:unauthorized)
     end
@@ -30,18 +31,21 @@ RSpec.describe 'Api::V1::Examples', type: :request do
     it "returns not_found for another user's wordbook" do
       other_wordbook = create(:wordbook)
       other_word = create(:word, wordbook: other_wordbook)
+      other_meaning = create(:meaning, word: other_word)
 
-      get "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples", headers: headers
+      get "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings/#{other_meaning.id}/examples",
+          headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe 'GET /api/v1/wordbooks/:wordbook_id/words/:word_id/examples/:id' do
+  describe 'GET /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:meaning_id/examples/:id' do
     it 'returns the example' do
-      example = create(:example, word: word, sentence: 'Good morning')
+      example = create(:example, meaning: meaning, sentence: 'Good morning')
 
-      get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples/#{example.id}", headers: headers
+      get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}/examples/#{example.id}",
+          headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['sentence']).to eq('Good morning')
@@ -50,15 +54,18 @@ RSpec.describe 'Api::V1::Examples', type: :request do
     it "returns not_found for another user's example" do
       other_wordbook = create(:wordbook)
       other_word = create(:word, wordbook: other_wordbook)
-      other_example = create(:example, word: other_word)
+      other_meaning = create(:meaning, word: other_word)
+      other_example = create(:example, meaning: other_meaning)
 
-      get "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples/#{other_example.id}", headers: headers
+      path = "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}" \
+             "/meanings/#{other_meaning.id}/examples/#{other_example.id}"
+      get path, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe 'POST /api/v1/wordbooks/:wordbook_id/words/:word_id/examples' do
+  describe 'POST /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:meaning_id/examples' do
     context 'with valid params' do
       it 'creates an example' do
         params = {
@@ -70,7 +77,8 @@ RSpec.describe 'Api::V1::Examples', type: :request do
         }
 
         expect do
-          post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples", params: params, headers: headers
+          post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}/examples",
+               params: params, headers: headers
         end.to change(Example, :count).by(1)
 
         expect(response).to have_http_status(:created)
@@ -79,29 +87,30 @@ RSpec.describe 'Api::V1::Examples', type: :request do
 
     context 'with invalid params' do
       it 'returns unprocessable_content' do
-        post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples",
+        post "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}/examples",
              params: { example: { sentence: '', translation: '翻訳', display_order: 1 } }, headers: headers
 
         expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
-    it 'returns not_found when word belongs to another user' do
+    it 'returns not_found when meaning belongs to another user' do
       other_wordbook = create(:wordbook)
       other_word = create(:word, wordbook: other_wordbook)
+      other_meaning = create(:meaning, word: other_word)
 
-      post "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples",
+      post "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/meanings/#{other_meaning.id}/examples",
            params: { example: { sentence: 'test', translation: 'test', display_order: 1 } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe 'PATCH /api/v1/wordbooks/:wordbook_id/words/:word_id/examples/:id' do
-    let(:example_record) { create(:example, word: word) }
+  describe 'PATCH /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:meaning_id/examples/:id' do
+    let(:example_record) { create(:example, meaning: meaning) }
 
     it 'updates the example' do
-      patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples/#{example_record.id}",
+      patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}/examples/#{example_record.id}",
             params: { example: { sentence: 'Updated sentence' } }, headers: headers
 
       expect(response).to have_http_status(:ok)
@@ -111,21 +120,24 @@ RSpec.describe 'Api::V1::Examples', type: :request do
     it "returns not_found for another user's example" do
       other_wordbook = create(:wordbook)
       other_word = create(:word, wordbook: other_wordbook)
-      other_example = create(:example, word: other_word)
+      other_meaning = create(:meaning, word: other_word)
+      other_example = create(:example, meaning: other_meaning)
 
-      patch "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples/#{other_example.id}",
-            params: { example: { sentence: 'hacked' } }, headers: headers
+      path = "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}" \
+             "/meanings/#{other_meaning.id}/examples/#{other_example.id}"
+      patch path, params: { example: { sentence: 'hacked' } }, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe 'DELETE /api/v1/wordbooks/:wordbook_id/words/:word_id/examples/:id' do
+  describe 'DELETE /api/v1/wordbooks/:wordbook_id/words/:word_id/meanings/:meaning_id/examples/:id' do
     it 'deletes the example' do
-      example_record = create(:example, word: word)
+      example_record = create(:example, meaning: meaning)
 
       expect do
-        delete "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/examples/#{example_record.id}", headers: headers
+        delete "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}/meanings/#{meaning.id}/examples/#{example_record.id}",
+               headers: headers
       end.to change(Example, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
@@ -134,10 +146,12 @@ RSpec.describe 'Api::V1::Examples', type: :request do
     it "returns not_found for another user's example" do
       other_wordbook = create(:wordbook)
       other_word = create(:word, wordbook: other_wordbook)
-      other_example = create(:example, word: other_word)
+      other_meaning = create(:meaning, word: other_word)
+      other_example = create(:example, meaning: other_meaning)
 
-      delete "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}/examples/#{other_example.id}",
-             headers: headers
+      path = "/api/v1/wordbooks/#{other_wordbook.id}/words/#{other_word.id}" \
+             "/meanings/#{other_meaning.id}/examples/#{other_example.id}"
+      delete path, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/requests/api/v1/test/words_spec.rb
+++ b/spec/requests/api/v1/test/words_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'Api::V1::Test::Words', type: :request do
   describe 'GET /api/v1/wordbooks/:wordbook_id/test/words' do
     it 'returns reviewable words with meanings and examples' do
       word = create(:word, wordbook: wordbook, next_review_at: nil)
-      create(:meaning, word: word, definition: 'りんご', display_order: 1)
-      create(:example, word: word, sentence: 'I like apples.', display_order: 1)
+      meaning = create(:meaning, word: word, definition: 'りんご', display_order: 1)
+      create(:example, meaning: meaning, sentence: 'I like apples.', display_order: 1)
 
       get "/api/v1/wordbooks/#{wordbook.id}/test/words", headers: headers
 
@@ -23,8 +23,8 @@ RSpec.describe 'Api::V1::Test::Words', type: :request do
       expect(returned_word['spelling']).to eq(word.spelling)
       expect(returned_word['meanings'].size).to eq(1)
       expect(returned_word['meanings'].first['definition']).to eq('りんご')
-      expect(returned_word['examples'].size).to eq(1)
-      expect(returned_word['examples'].first['sentence']).to eq('I like apples.')
+      expect(returned_word['meanings'].first['examples'].size).to eq(1)
+      expect(returned_word['meanings'].first['examples'].first['sentence']).to eq('I like apples.')
     end
 
     it 'includes words with next_review_at in the past' do
@@ -45,16 +45,16 @@ RSpec.describe 'Api::V1::Test::Words', type: :request do
 
     it 'returns meanings and examples sorted by display_order' do
       word = create(:word, wordbook: wordbook, next_review_at: nil)
-      create(:meaning, word: word, definition: 'second', display_order: 2)
-      create(:meaning, word: word, definition: 'first', display_order: 1)
-      create(:example, word: word, sentence: 'Second', display_order: 2)
-      create(:example, word: word, sentence: 'First', display_order: 1)
+      second_meaning = create(:meaning, word: word, definition: 'second', display_order: 2)
+      first_meaning = create(:meaning, word: word, definition: 'first', display_order: 1)
+      create(:example, meaning: second_meaning, sentence: 'Second', display_order: 2)
+      create(:example, meaning: first_meaning, sentence: 'First', display_order: 1)
 
       get "/api/v1/wordbooks/#{wordbook.id}/test/words", headers: headers
 
       returned_word = response.parsed_body['words'].first
       expect(returned_word['meanings'].pluck('definition')).to eq(%w[first second])
-      expect(returned_word['examples'].pluck('sentence')).to eq(%w[First Second])
+      expect(returned_word['meanings'].first['examples'].first['sentence']).to eq('First')
     end
 
     it 'returns empty words array when no reviewable words exist' do

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -77,45 +77,48 @@ RSpec.describe 'Api::V1::Words', type: :request do
 
     context 'with include parameter' do
       let(:word) { create(:word, wordbook: wordbook) }
+      let(:secondary_meaning) { create(:meaning, word: word, definition: 'meaning1', display_order: 2) }
+      let(:primary_meaning) { create(:meaning, word: word, definition: 'meaning2', display_order: 1) }
 
       before do
-        create(:meaning, word: word, definition: 'meaning1', display_order: 2)
-        create(:meaning, word: word, definition: 'meaning2', display_order: 1)
-        create(:example, word: word, sentence: 'Example1', display_order: 2)
-        create(:example, word: word, sentence: 'Example2', display_order: 1)
+        create(:example, meaning: secondary_meaning, sentence: 'Example1', display_order: 2)
+        create(:example, meaning: primary_meaning, sentence: 'Example2', display_order: 1)
       end
 
       it 'includes meanings when include=meanings' do
-        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=meanings", headers: headers
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=meanings",
+            headers: headers
 
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
         expect(body['meanings'].size).to eq(2)
         expect(body['meanings'].pluck('definition')).to eq(%w[meaning2 meaning1])
-        expect(body).not_to have_key('examples')
+        expect(body['meanings'].first).not_to have_key('examples')
       end
 
-      it 'includes examples when include=examples' do
-        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=examples", headers: headers
-
-        expect(response).to have_http_status(:ok)
-        body = response.parsed_body
-        expect(body['examples'].size).to eq(2)
-        expect(body['examples'].pluck('sentence')).to eq(%w[Example2 Example1])
-        expect(body).not_to have_key('meanings')
-      end
-
-      it 'includes both when include=meanings,examples' do
-        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=meanings,examples", headers: headers
+      it 'includes examples nested in meanings when include=examples' do
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=examples",
+            headers: headers
 
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
         expect(body['meanings'].size).to eq(2)
-        expect(body['examples'].size).to eq(2)
+        expect(body['meanings'].first['examples'].size).to eq(1)
+      end
+
+      it 'includes meanings with examples when include=meanings,examples' do
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=meanings,examples",
+            headers: headers
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body['meanings'].size).to eq(2)
+        expect(body['meanings'].first['examples'].size).to eq(1)
       end
 
       it 'ignores invalid include values' do
-        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=wordbook,invalid", headers: headers
+        get "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}?include=wordbook,invalid",
+            headers: headers
 
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
@@ -129,14 +132,13 @@ RSpec.describe 'Api::V1::Words', type: :request do
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
         expect(body).not_to have_key('meanings')
-        expect(body).not_to have_key('examples')
       end
     end
   end
 
   describe 'POST /api/v1/wordbooks/:wordbook_id/words' do
     context 'with valid params' do
-      it 'creates a word and returns meanings and examples in response' do
+      it 'creates a word and returns meanings in response' do
         expect do
           post "/api/v1/wordbooks/#{wordbook.id}/words",
                params: { word: { spelling: 'banana' } }, headers: headers
@@ -147,7 +149,6 @@ RSpec.describe 'Api::V1::Words', type: :request do
         expect(body['spelling']).to eq('banana')
         expect(body['status']).to eq('not_studied')
         expect(body['meanings']).to eq([])
-        expect(body['examples']).to eq([])
       end
     end
 
@@ -176,38 +177,18 @@ RSpec.describe 'Api::V1::Words', type: :request do
       end
     end
 
-    context 'with examples_attributes' do
-      let(:params) do
-        {
-          word: {
-            spelling: 'hello',
-            examples_attributes: [
-              { sentence: 'Hello, world!', translation: 'こんにちは、世界！', display_order: 1 }
-            ]
-          }
-        }
-      end
-
-      it 'creates a word with examples in a single request' do
-        expect do
-          post "/api/v1/wordbooks/#{wordbook.id}/words", params: params, headers: headers
-        end.to change(Word, :count).by(1).and change(Example, :count).by(1)
-
-        expect(response).to have_http_status(:created)
-        body = response.parsed_body
-        expect(body['examples'].size).to eq(1)
-        expect(body['examples'].first['sentence']).to eq('Hello, world!')
-      end
-    end
-
-    context 'with both meanings_attributes and examples_attributes' do
+    context 'with meanings_attributes containing examples_attributes' do
       let(:params) do
         {
           word: {
             spelling: 'run',
-            meanings_attributes: [{ definition: '走る', display_order: 1 }],
-            examples_attributes: [
-              { sentence: 'I run every morning.', translation: '毎朝走ります。', display_order: 1 }
+            meanings_attributes: [
+              {
+                definition: '走る', display_order: 1,
+                examples_attributes: [
+                  { sentence: 'I run every morning.', translation: '毎朝走ります。', display_order: 1 }
+                ]
+              }
             ]
           }
         }
@@ -223,7 +204,8 @@ RSpec.describe 'Api::V1::Words', type: :request do
         expect(response).to have_http_status(:created)
         body = response.parsed_body
         expect(body['meanings'].size).to eq(1)
-        expect(body['examples'].size).to eq(1)
+        expect(body['meanings'].first['examples'].size).to eq(1)
+        expect(body['meanings'].first['examples'].first['sentence']).to eq('I run every morning.')
       end
     end
 
@@ -249,7 +231,10 @@ RSpec.describe 'Api::V1::Words', type: :request do
         params = {
           word: {
             spelling: 'apple',
-            examples_attributes: [{ sentence: '', translation: 'trans', display_order: 1 }]
+            meanings_attributes: [
+              { definition: 'りんご', display_order: 1,
+                examples_attributes: [{ sentence: '', translation: 'trans', display_order: 1 }] }
+            ]
           }
         }
 


### PR DESCRIPTION
## Summary
- Move `examples` foreign key from `words` to `meanings`, changing the data model from `Word → Example` to `Word → Meaning → Example`
- Update API response structure: examples are now nested inside meanings when included
- Update routes: examples CRUD is now nested under meanings (`/meanings/:meaning_id/examples`)
- Existing data is migrated by assigning examples to the first meaning (by display_order) of their word

Closes #139