### PR TITLE
refactor(model): use symbol form for guest validation conditions

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,8 +18,8 @@ class User < ApplicationRecord
 
   validates :email, uniqueness: { allow_nil: true }
   validates :provider, presence: true
-  validates :provider_uid, presence: true, uniqueness: { scope: :provider }, unless: -> { guest? }
-  validates :guest_expires_at, presence: true, if: -> { provider == 'guest' }
+  validates :provider_uid, presence: true, uniqueness: { scope: :provider }, unless: :guest?
+  validates :guest_expires_at, presence: true, if: :guest?
 
   enum :provider, { google: 'google', guest: 'guest' }
 


### PR DESCRIPTION
## Summary
- Replace lambda-based `unless`/`if` options on `User` validations with symbol shorthand (`:guest?`)
- The `guest?` predicate is auto-generated by the `provider` enum, so the lambdas were unnecessary

## Test plan
- [x] `bundle exec rspec spec/models/user_spec.rb` (29 examples, 0 failures)