### PR TITLE
refactor(model): tidy guest validations and enum declarations

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
   validates :provider_uid, presence: true, uniqueness: { scope: :provider }, unless: :guest?
   validates :guest_expires_at, presence: true, if: :guest?
 
-  enum :provider, { google: 'google', guest: 'guest' }
+  enum :provider, google: 'google', guest: 'guest'
 
   def self.find_by_token(token)
     payload = JsonWebToken.decode(token)

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -11,7 +11,7 @@ class Word < ApplicationRecord
   validates :spelling, presence: true, length: { maximum: 255 }
   validates :status, presence: true
 
-  enum :status, { not_studied: 'not_studied', hard: 'hard', uncertain: 'uncertain', easy: 'easy' }
+  enum :status, not_studied: 'not_studied', hard: 'hard', uncertain: 'uncertain', easy: 'easy'
 
   scope :reviewable, -> { where('next_review_at IS NULL OR next_review_at <= ?', Time.current) }
 end


### PR DESCRIPTION
## Summary
- Replace lambda-based `unless`/`if` options on guest validations with symbol shorthand, since `guest?` is auto-generated by the `provider` enum.
- Drop redundant braces from the `enum` value hashes in `User#provider` and `Word#status`; `enum` accepts the value hash as keyword arguments, so the braces add no information.

## Test plan
- [x] `bundle exec rspec spec/models/user_spec.rb spec/models/word_spec.rb`
- [x] `bundle exec rubocop app/models/user.rb app/models/word.rb`