### PR TITLE
refactor(model): use inverse_of: :word for first_meaning

### DIFF
--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -4,7 +4,7 @@ class Word < ApplicationRecord
   belongs_to :wordbook
   has_many :meanings, dependent: :destroy
   has_many :examples, through: :meanings
-  has_one :first_meaning, -> { order(:display_order) }, class_name: 'Meaning', dependent: nil, inverse_of: false
+  has_one :first_meaning, -> { order(:display_order) }, class_name: 'Meaning', dependent: nil, inverse_of: :word
 
   accepts_nested_attributes_for :meanings
 

--- a/docs/rubocop_configuration.md
+++ b/docs/rubocop_configuration.md
@@ -193,7 +193,7 @@ RSpec cop のデフォルト閾値は非常に厳しいため、実用的な範�
 #### Rails/InverseOf
 
 - **内容**: カスタムクラス名やスコープを持つアソシエーションに `:inverse_of` を指定する
-- **対応**: `has_one :first_meaning` に `inverse_of: false` を追加（対称的な逆アソシエーションを持たないスコープ付きアソシエーション）
+- **対応**: `has_one :first_meaning` に `inverse_of: :word` を指定。`Meaning#belongs_to :word` は無スコープなので逆方向の指定は安全で、`word.first_meaning.word` が再クエリせずロード済みの `word` を返せる。
 
 #### Rails/SkipsModelValidations
 


### PR DESCRIPTION
## Summary
- Replace `inverse_of: false` with `inverse_of: :word` on `Word#first_meaning` so that `word.first_meaning.word` returns the already-loaded `word` instance instead of triggering an extra query.
- The forward scope (`order(:display_order)`) only affects fetching the meaning; `Meaning#belongs_to :word` is unscoped, so specifying the inverse is safe.
- Update `docs/rubocop_configuration.md` to reflect the new rationale for the `Rails/InverseOf` setting.

## Test plan
- [x] `bundle exec rubocop app/models/word.rb` — no offenses.
- [x] `bundle exec rspec spec/models/word_spec.rb spec/requests/api/v1/words_spec.rb` — all green.