### PR TITLE
feat(auth): sync Google profile on every login

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -41,6 +41,8 @@ module Api
           user = User.find_by!(provider: 'google', provider_uid: payload['sub'])
         end
 
+        user.sync_google_profile!(payload)
+
         render json: { user: JSON.parse(UserResource.new(user, params: { type: :google }).serialize),
                        token: JsonWebToken.encode(user.id) },
                status: :ok

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ApplicationRecord
       existing_google_user = User.find_by(provider: 'google', provider_uid: google_payload['sub'])
 
       if existing_google_user
-        merge_into_google_user(existing_google_user)
+        merge_into_google_user(existing_google_user, google_payload)
       else
         convert_to_google(google_payload)
       end
@@ -46,6 +46,13 @@ class User < ApplicationRecord
 
   def effective_setting
     setting || Setting.default
+  end
+
+  def sync_google_profile!(google_payload)
+    changes = {}
+    changes[:name] = google_payload['name'] if name != google_payload['name']
+    changes[:avatar_url] = google_payload['picture'] if avatar_url != google_payload['picture']
+    update!(changes) if changes.any?
   end
 
   private
@@ -63,7 +70,8 @@ class User < ApplicationRecord
     MigrationResult.success(self)
   end
 
-  def merge_into_google_user(google_user)
+  def merge_into_google_user(google_user, google_payload)
+    google_user.sync_google_profile!(google_payload)
     wordbooks.update_all(user_id: google_user.id) # rubocop:disable Rails/SkipsModelValidations
     setting.update!(user_id: google_user.id) if setting.present? && google_user.setting.blank?
     reload.destroy!

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -134,6 +134,34 @@ RSpec.describe 'Api::V1::Auth', type: :request do
       end
     end
 
+    context 'when token is valid and user already exists with stale profile' do
+      let!(:existing_user) do
+        create(
+          :user,
+          provider: 'google',
+          provider_uid: 'google_uid_123',
+          email: 'test@example.com',
+          name: 'Old Name',
+          avatar_url: 'https://example.com/old.jpg'
+        )
+      end
+
+      before do
+        allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return(google_payload)
+      end
+
+      it 'refreshes name and avatar_url from the payload without changing email' do
+        post '/api/v1/auth/google', headers: { 'Authorization' => 'Bearer valid_token' }
+
+        expect(response).to have_http_status(:ok)
+
+        existing_user.reload
+        expect(existing_user.name).to eq('Test User')
+        expect(existing_user.avatar_url).to eq('https://example.com/avatar.jpg')
+        expect(existing_user.email).to eq('test@example.com')
+      end
+    end
+
     context 'when RecordNotUnique is raised (race condition)' do
       let!(:existing_user) do
         create(:user, provider: 'google', provider_uid: 'google_uid_123', email: 'test@example.com')
@@ -246,7 +274,14 @@ RSpec.describe 'Api::V1::Auth', type: :request do
 
       context 'when Google account already exists (merge)' do
         let!(:google_user) do
-          create(:user, provider: 'google', provider_uid: 'google_uid_123', email: 'test@example.com')
+          create(
+            :user,
+            provider: 'google',
+            provider_uid: 'google_uid_123',
+            email: 'test@example.com',
+            name: 'Old Name',
+            avatar_url: 'https://example.com/old.jpg'
+          )
         end
         let!(:guest_wordbook) { create(:wordbook, user: guest_user, title: 'Guest Wordbook') }
         let!(:guest_word) { create(:word, wordbook: guest_wordbook, spelling: 'banana') }
@@ -301,6 +336,16 @@ RSpec.describe 'Api::V1::Auth', type: :request do
           token = response.parsed_body['token']
           decoded = JsonWebToken.decode(token)
           expect(decoded['sub']).to eq(google_user.id)
+        end
+
+        it 'refreshes the merged-into Google user name and avatar_url from the payload' do
+          post '/api/v1/auth/google',
+               params: { guest_token: guest_token },
+               headers: { 'Authorization' => 'Bearer valid_token' }
+
+          google_user.reload
+          expect(google_user.name).to eq('Test User')
+          expect(google_user.avatar_url).to eq('https://example.com/avatar.jpg')
         end
       end
 


### PR DESCRIPTION
## Summary
- Refresh `name` / `avatar_url` from the latest Google ID token payload on every Google login, so profile updates made on the Google side propagate to the local user record (previously they were frozen at sign-up values).
- Apply the same sync in the guest → existing-Google merge path (`User#merge_into_google_user`) for behavioral consistency.
- Skip the `UPDATE` when payload values match stored values to avoid unnecessary writes. `email` is intentionally not synced (would require non-trivial uniqueness handling).

## Test plan
- [x] \`bundle exec rspec spec/requests/api/v1/auth_spec.rb\`
- [x] \`bundle exec rubocop app/controllers/api/v1/auth_controller.rb app/models/user.rb spec/requests/api/v1/auth_spec.rb\`
- [x] New spec: existing Google user re-login refreshes \`name\` / \`avatar_url\` and leaves \`email\` unchanged.
- [x] New spec: guest → existing-Google merge refreshes the merged-into user's \`name\` / \`avatar_url\`.

Closes #145