### PR TITLE
feat(user): add DELETE /api/v1/user endpoint

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    class UsersController < ApplicationController
+      def destroy
+        current_user.destroy!
+        head :no_content
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
         end
       end
       resource :setting, only: %i[show create update destroy]
+      resource :user, only: [:destroy]
     end
   end
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -862,6 +862,24 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  # ──────────────── User (singular resource) ────────────────
+  /api/v1/user:
+    delete:
+      tags: [Users]
+      summary: Delete the current user account
+      description: |
+        Permanently deletes the authenticated user and all associated data
+        (wordbooks, words, meanings, examples, settings) via cascading deletes.
+        The JWT token is not revoked server-side, but subsequent requests with
+        the orphaned token will return 401.
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: No Content
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
 components:
   securitySchemes:
     googleIdToken:

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Users', type: :request do
+  let(:user) { create(:user) }
+  let(:headers) { auth_headers_for(user) }
+
+  describe 'DELETE /api/v1/user' do
+    it 'deletes the current user and returns 204' do
+      user
+
+      expect do
+        delete '/api/v1/user', headers: headers
+      end.to change(User, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'cascades to associated wordbooks and setting' do
+      create(:wordbook, user: user)
+      create(:setting, user: user)
+
+      expect do
+        delete '/api/v1/user', headers: headers
+      end.to change(Wordbook, :count).by(-1)
+                                     .and change(Setting, :count).by(-1)
+    end
+
+    it 'deletes a guest user' do
+      guest = create(:user, :guest)
+      guest_headers = auth_headers_for(guest)
+
+      expect do
+        delete '/api/v1/user', headers: guest_headers
+      end.to change(User, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'returns 401 without authentication' do
+      delete '/api/v1/user'
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `DELETE /api/v1/user` as a singleton route (`resource :user, only: [:destroy]`) so an authenticated user can permanently delete their own account.
- New `Api::V1::UsersController#destroy` calls `current_user.destroy!` and returns 204. Existing `dependent: :destroy` cascades on `User` clean up wordbooks, words, meanings, examples, and settings.
- Document the endpoint in `docs/openapi.yaml` under a new `Users` tag.

JWT revocation is intentionally out of scope: tokens are stateless HS256 and `User.find_by_token` returns `nil` after the user is deleted, so the next request with the orphaned token will 401 via `authenticate_user!`. Both `google` and `guest` users share the same code path.

Closes #146

## Test plan

- [x] `bundle exec rspec spec/requests/api/v1/users_spec.rb` (4 examples, 0 failures)
- [x] `bundle exec rspec` (full suite — only an unrelated flaky timing test in `words_spec.rb` failed once and passed on rerun)
- [x] `bundle exec rubocop` on changed files (no offenses)
- [x] `ruby -ryaml` validation of `docs/openapi.yaml`
- [x] Manual: `POST /api/v1/auth/guest` → `DELETE /api/v1/user` returns 204; reusing the same token returns 401