### PR TITLE
Allow nested update of meanings/examples in Words#update

### DIFF
--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -65,8 +65,10 @@ module Api
       def update_word_params
         params.expect(word: [
                         :spelling, :status,
-                        { meanings_attributes: [[:definition, :display_order,
-                                                 { examples_attributes: [%i[sentence translation display_order]] }]] }
+                        { meanings_attributes: [
+                          [:id, :definition, :display_order,
+                           { examples_attributes: [%i[id sentence translation display_order]] }]
+                        ] }
                       ])
       end
     end

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -374,7 +374,19 @@ paths:
           $ref: "#/components/responses/NotFound"
     patch:
       tags: [Words]
-      summary: Update a word
+      summary: Update a word with optional nested meanings and examples
+      description: |
+        Updates a word. Optionally accepts nested `meanings_attributes`
+        (with `examples_attributes` inside each meaning) to update or create
+        related records in a single atomic transaction.
+
+        For each nested item, supplying `id` updates the existing record
+        (only the fields you include are changed); omitting `id` creates a
+        new record (all required fields must be provided).
+
+        Deletion is not supported through nested attributes — use the
+        dedicated `DELETE /meanings/{id}` and `DELETE /examples/{id}`
+        endpoints instead.
       security:
         - bearerAuth: []
       requestBody:
@@ -392,6 +404,40 @@ paths:
                       type: string
                     status:
                       $ref: "#/components/schemas/WordStatus"
+                    meanings_attributes:
+                      type: array
+                      description: |
+                        Nested meanings to update or create. Include `id` to update an
+                        existing meaning; omit `id` to create a new one.
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                            description: ID of the existing meaning to update. Omit when creating a new meaning.
+                          definition:
+                            type: string
+                          display_order:
+                            type: integer
+                            minimum: 1
+                          examples_attributes:
+                            type: array
+                            description: |
+                              Nested examples to update or create. Include `id` to update an
+                              existing example; omit `id` to create a new one.
+                            items:
+                              type: object
+                              properties:
+                                id:
+                                  type: integer
+                                  description: ID of the existing example to update. Omit when creating a new example.
+                                sentence:
+                                  type: string
+                                translation:
+                                  type: string
+                                display_order:
+                                  type: integer
+                                  minimum: 1
       responses:
         "200":
           description: Updated

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -334,6 +334,61 @@ RSpec.describe 'Api::V1::Words', type: :request do
         end
       end
     end
+
+    context 'with meanings_attributes' do
+      it 'updates an existing meaning when id is supplied' do
+        meaning = create(:meaning, word: word, definition: 'old', display_order: 1)
+
+        patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}",
+              params: { word: { meanings_attributes: [{ id: meaning.id, definition: 'new' }] } },
+              headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(meaning.reload.definition).to eq('new')
+      end
+
+      it 'creates a new meaning when id is omitted' do
+        expect do
+          patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}",
+                params: { word: { meanings_attributes: [{ definition: 'added', display_order: 1 }] } },
+                headers: headers
+        end.to change(word.meanings, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+        expect(word.meanings.last.definition).to eq('added')
+      end
+
+      it 'updates an existing example when id is supplied in nested examples_attributes' do
+        meaning = create(:meaning, word: word, definition: 'def', display_order: 1)
+        example = create(:example, meaning: meaning, sentence: 'old sentence',
+                                   translation: 'old', display_order: 1)
+
+        patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}",
+              params: { word: { meanings_attributes: [
+                { id: meaning.id, examples_attributes: [{ id: example.id, sentence: 'new sentence' }] }
+              ] } },
+              headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(example.reload.sentence).to eq('new sentence')
+      end
+
+      it 'creates a new example for an existing meaning when example id is omitted' do
+        meaning = create(:meaning, word: word, definition: 'def', display_order: 1)
+
+        expect do
+          patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}",
+                params: { word: { meanings_attributes: [
+                  { id: meaning.id, examples_attributes: [
+                    { sentence: 'added', translation: 'trans', display_order: 1 }
+                  ] }
+                ] } },
+                headers: headers
+        end.to change(meaning.examples, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   describe 'DELETE /api/v1/wordbooks/:wordbook_id/words/:id' do


### PR DESCRIPTION
## Summary
- Permit `:id` on `meanings_attributes` and `examples_attributes` in `Words#update` so existing nested records can be updated through `PATCH /api/v1/wordbooks/:wordbook_id/words/:id`. New records are still created when `id` is omitted.
- Update `docs/openapi.yaml` to document the nested structure for the word update endpoint, mirroring the create endpoint and noting that deletion still goes through the dedicated `DELETE /meanings/:id` and `DELETE /examples/:id` endpoints.

## Test plan
- [x] `bundle exec rspec spec/requests/api/v1/words_spec.rb`
- [x] Added request specs covering nested update of an existing meaning, nested creation of a new meaning, and the same pair for examples.
- [x] Verified `docs/openapi.yaml` parses as valid YAML.