### PR TITLE
Make PATCH /api/v1/setting upsert to fix first-time save for new users

### DIFF
--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class SettingsController < ApplicationController
-      before_action :set_setting, only: %i[update destroy]
+      before_action :set_setting, only: %i[destroy]
 
       def show
         render json: SettingResource.new(current_user.effective_setting).serialize
@@ -14,8 +14,10 @@ module Api
       end
 
       def update
-        @setting.update!(build_setting_params)
-        render json: SettingResource.new(@setting).serialize
+        setting = current_user.setting || current_user.build_setting
+        setting.assign_attributes(build_setting_params)
+        setting.save!
+        render json: SettingResource.new(setting).serialize
       end
 
       def destroy

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -88,31 +88,55 @@ RSpec.describe 'Api::V1::Settings', type: :request do
   end
 
   describe 'PATCH /api/v1/setting' do
-    let!(:setting) { create(:setting, user: user) }
+    context 'when the user already has a setting' do
+      let!(:setting) { create(:setting, user: user) }
 
-    it 'updates the setting' do
-      patch '/api/v1/setting', params: {
-        setting: {
-          hard_interval: { days: 2, hours: 0, minutes: 0 }
-        }
-      }, headers: headers
+      it 'updates the setting without creating a new record' do
+        expect do
+          patch '/api/v1/setting', params: {
+            setting: {
+              hard_interval: { days: 2, hours: 0, minutes: 0 }
+            }
+          }, headers: headers
+        end.not_to change(Setting, :count)
 
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body['hard_interval']).to eq({ 'days' => 2, 'hours' => 0, 'minutes' => 0 })
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['hard_interval']).to eq({ 'days' => 2, 'hours' => 0, 'minutes' => 0 })
+      end
+
+      context 'with intervals not in ascending order' do
+        it 'returns unprocessable_content with error message' do
+          patch '/api/v1/setting', params: {
+            setting: {
+              hard_interval: { days: 1, hours: 0, minutes: 0 },
+              uncertain_interval: { days: 10, hours: 0, minutes: 0 },
+              easy_interval: { days: 3, hours: 0, minutes: 0 }
+            }
+          }, headers: headers
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.parsed_body['error']).to eq('Unprocessable entity')
+        end
+      end
     end
 
-    context 'with intervals not in ascending order' do
-      it 'returns unprocessable_content with error message' do
-        patch '/api/v1/setting', params: {
+    context 'when the user has no setting yet' do
+      it 'creates a setting and returns it' do
+        params = {
           setting: {
-            hard_interval: { days: 1, hours: 0, minutes: 0 },
-            uncertain_interval: { days: 10, hours: 0, minutes: 0 },
-            easy_interval: { days: 3, hours: 0, minutes: 0 }
+            hard_interval: { days: 1, hours: 0, minutes: 1 },
+            uncertain_interval: { days: 3, hours: 0, minutes: 0 },
+            easy_interval: { days: 7, hours: 0, minutes: 0 }
           }
-        }, headers: headers
+        }
 
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(response.parsed_body['error']).to eq('Unprocessable entity')
+        expect do
+          patch '/api/v1/setting', params: params, headers: headers
+        end.to change(Setting, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+        expect(Setting.last.user_id).to eq(user.id)
+        expect(response.parsed_body['hard_interval']).to eq({ 'days' => 1, 'hours' => 0, 'minutes' => 1 })
       end
     end
   end


### PR DESCRIPTION
## Summary

- New users (notably guest users) are created without a `Setting` row. The first `PATCH /api/v1/setting` from the client therefore raised `ActiveRecord::RecordNotFound` and returned 404, blocking the initial save flow.
- `show` and `next_review_at` already fall back to `Setting.default` via `User#effective_setting`, so the inconsistency was only on the write path.
- Make `update` build a Setting via `has_one#build_setting` when the user has none, then `assign_attributes` and `save!`. Behavior is unchanged for users who already have a Setting. `create` and `destroy` are intentionally left as-is.

## Test plan

- [x] `bundle exec rspec spec/requests/api/v1/settings_spec.rb`
- [x] `bundle exec rspec` (full suite, 258 examples, 0 failures)
- [x] Added request specs covering both branches: PATCH with no existing setting creates one, PATCH with an existing setting updates it without creating a new record
