### PR TITLE
fix(word): recalculate next_review_at when same status is re-selected

### DIFF
--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -2,17 +2,33 @@ module Reviewable
   extend ActiveSupport::Concern
 
   included do
-    before_update :recalculate_next_review_at, if: :status_changed?
+    before_update :recalculate_next_review_at, if: :status_assigned?
+    after_save :reset_status_assigned_flag
+
+    prepend(Module.new do
+      def status=(value)
+        @status_assigned = true
+        super
+      end
+    end)
   end
 
   private
+
+  def status_assigned?
+    @status_assigned == true
+  end
+
+  def reset_status_assigned_flag
+    @status_assigned = false
+  end
 
   def recalculate_next_review_at
     setting = wordbook.user.effective_setting
 
     if status.to_sym == :not_studied
       self.next_review_at = nil
-    elsif next_review_at.nil? || status_was.to_sym == :not_studied || next_review_at <= Time.current
+    elsif !status_changed? || next_review_at.nil? || status_was.to_sym == :not_studied || next_review_at <= Time.current
       self.next_review_at = Time.current + interval_for(status, setting)
     else
       adjustment = interval_for(status, setting) - interval_for(status_was, setting)

--- a/spec/models/concerns/reviewable_spec.rb
+++ b/spec/models/concerns/reviewable_spec.rb
@@ -85,6 +85,50 @@ RSpec.describe Reviewable, type: :model do
       end
     end
 
+    context 'when reselecting the same status (hard) with future next_review_at' do
+      let(:word) { create(:word, wordbook: wordbook, status: 'hard', next_review_at: 5.days.from_now) }
+
+      it 'resets next_review_at to now + hard_interval' do
+        freeze_time do
+          word.update!(status: 'hard')
+          expect(word.next_review_at).to eq(1.day.from_now)
+        end
+      end
+    end
+
+    context 'when reselecting the same status (uncertain) with future next_review_at' do
+      let(:word) { create(:word, wordbook: wordbook, status: 'uncertain', next_review_at: 10.days.from_now) }
+
+      it 'resets next_review_at to now + uncertain_interval' do
+        freeze_time do
+          word.update!(status: 'uncertain')
+          expect(word.next_review_at).to eq(3.days.from_now)
+        end
+      end
+    end
+
+    context 'when reselecting the same status (easy) with future next_review_at' do
+      let(:word) { create(:word, wordbook: wordbook, status: 'easy', next_review_at: 20.days.from_now) }
+
+      it 'resets next_review_at to now + easy_interval' do
+        freeze_time do
+          word.update!(status: 'easy')
+          expect(word.next_review_at).to eq(7.days.from_now)
+        end
+      end
+    end
+
+    context 'when reselecting the same status with past next_review_at' do
+      let(:word) { create(:word, wordbook: wordbook, status: 'hard', next_review_at: 2.days.ago) }
+
+      it 'resets next_review_at to now + interval' do
+        freeze_time do
+          word.update!(status: 'hard')
+          expect(word.next_review_at).to eq(1.day.from_now)
+        end
+      end
+    end
+
     context 'with custom user settings' do
       let!(:setting) do
         create(:setting, user: user, hard_interval: 2.days, uncertain_interval: 4.days, easy_interval: 10.days)

--- a/spec/requests/api/v1/words_spec.rb
+++ b/spec/requests/api/v1/words_spec.rb
@@ -335,6 +335,20 @@ RSpec.describe 'Api::V1::Words', type: :request do
       end
     end
 
+    context 'when the same status is re-selected' do
+      it 'resets next_review_at to now + interval' do
+        word = create(:word, wordbook: wordbook, status: 'hard', next_review_at: 5.days.from_now)
+
+        freeze_time do
+          patch "/api/v1/wordbooks/#{wordbook.id}/words/#{word.id}",
+                params: { word: { status: 'hard' } }, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          expect(Time.zone.parse(response.parsed_body['next_review_at'])).to eq(1.day.from_now)
+        end
+      end
+    end
+
     context 'with meanings_attributes' do
       it 'updates an existing meaning when id is supplied' do
         meaning = create(:meaning, word: word, definition: 'old', display_order: 1)


### PR DESCRIPTION
## Summary
- Reselecting the current status (hard/uncertain/easy) during a test session did not update `next_review_at` because the `before_update` callback was gated on `status_changed?`.
- Override `status=` via `prepend` in `Reviewable` so the callback now fires whenever status is explicitly assigned, even to the same value.
- When the same status is reselected, reset `next_review_at` to `Time.current + interval_for(status)` instead of falling through the no-op adjustment branch.

## Test plan
- [x] `bundle exec rspec spec/models/concerns/reviewable_spec.rb spec/requests/api/v1/words_spec.rb`
- [x] `bundle exec rspec` (full suite)