### PR TITLE
fix(user): expose account deletion at /api/v1/users/me

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
         end
       end
       resource :setting, only: %i[show create update destroy]
-      resource :user, only: [:destroy]
+      delete 'users/me', to: 'users#destroy', as: :user
     end
   end
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -906,8 +906,8 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
-  # ──────────────── User (singular resource) ────────────────
-  /api/v1/user:
+  # ──────────────── Current User ────────────────
+  /api/v1/users/me:
     delete:
       tags: [Users]
       summary: Delete the current user account

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'Api::V1::Users', type: :request do
   let(:user) { create(:user) }
   let(:headers) { auth_headers_for(user) }
 
-  describe 'DELETE /api/v1/user' do
+  describe 'DELETE /api/v1/users/me' do
     it 'deletes the current user and returns 204' do
       user
 
       expect do
-        delete '/api/v1/user', headers: headers
+        delete '/api/v1/users/me', headers: headers
       end.to change(User, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
@@ -20,7 +20,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
       create(:setting, user: user)
 
       expect do
-        delete '/api/v1/user', headers: headers
+        delete '/api/v1/users/me', headers: headers
       end.to change(Wordbook, :count).by(-1)
                                      .and change(Setting, :count).by(-1)
     end
@@ -30,14 +30,14 @@ RSpec.describe 'Api::V1::Users', type: :request do
       guest_headers = auth_headers_for(guest)
 
       expect do
-        delete '/api/v1/user', headers: guest_headers
+        delete '/api/v1/users/me', headers: guest_headers
       end.to change(User, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end
 
     it 'returns 401 without authentication' do
-      delete '/api/v1/user'
+      delete '/api/v1/users/me'
 
       expect(response).to have_http_status(:unauthorized)
     end


### PR DESCRIPTION
## Summary
- Move the account-delete route from singular `/api/v1/user` to the conventional `/api/v1/users/me`, matching what the client expects (previously returned `ActionController::RoutingError`).
- Update the request spec paths and the OpenAPI doc to follow.
- Keep the `api_v1_user_path` URL helper name (`as: :user`) to avoid touching other callers.

## Test plan
- [x] `bundle exec rspec spec/requests/api/v1/users_spec.rb` (4 examples, 0 failures)
- [x] `bundle exec rails routes | grep users/me` shows `DELETE /api/v1/users/me`